### PR TITLE
fix(frontend): hot-fix frontend attempting to modify invalid drafts from local storage

### DIFF
--- a/frontend-dev/src/hooks/use-workflows.ts
+++ b/frontend-dev/src/hooks/use-workflows.ts
@@ -121,6 +121,10 @@ export function usePersistWorkflowDrafts() {
           } catch (error: any) {
             if (error?.response?.status === 404) {
               toast.error(`Can't find workflow '${draft.name || workflowId}'. It may have been deleted.`);
+            } else if (error?.response?.status === 403) {
+              // TODO: Because this attempts to persist all drafts, in case you switched account but your browser still has drafts
+              //  from the previous user, you may get a lot of these errors. We should either remove the drafts on user switch, or just persist
+              //  just the active course drafts or at least just the active workflow's draft.  
             } else {
               throw error;
             }


### PR DESCRIPTION
If you switched users in frontend, your local storage would still remember your drafts from that previous user. If your new user has a course and attempts to modify some workflow from that course, workflow-sidebar will attempt to persist ALL drafts from local storage, including the past user ones. That means a lot of 403 errors since current user doesn't have access to those. 

This is an ugly hotfix, and a proper solution should be implemented. #42 is a discussion on how this should be fixed.