### PR TITLE
fix(build): suppress warnings for module level directives in Vite configuration

### DIFF
--- a/frontend-dev/vite.config.mjs
+++ b/frontend-dev/vite.config.mjs
@@ -11,5 +11,15 @@ export default defineConfig({
   },
   server: {
     port: 3000,
-  }
+  },
+  build: {
+    rollupOptions: {
+      onwarn(warning, warn) {
+        if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
+          return;
+        }
+        warn(warning);
+      },
+    },
+  },
 })


### PR DESCRIPTION
This PR adds a vite configuration to ignore warnings related to nextjs directives