### PR TITLE
feat: add orphan artifacts cleanup job

### DIFF
--- a/scripts/orphan_cleanup.py
+++ b/scripts/orphan_cleanup.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from fair_platform.backend.jobs.orphan_cleanup import run_orphan_cleanup_once
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Debug tool: run orphan cleanup exactly like the background job. "
+            "Defaults to dry-run; use --apply to perform deletions."
+        )
+    )
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply changes (delete files/rows). Without this, runs in dry-run mode.",
+    )
+    p.add_argument(
+        "--retention-days",
+        type=int,
+        default=7,
+        help="Hard-delete orphaned items older than N days (default: 7).",
+    )
+    p.add_argument(
+        "--uploads-dir",
+        type=Path,
+        default=None,
+        help="Override uploads directory (default: platform storage uploads dir).",
+    )
+    p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print per-item details.",
+    )
+    return p
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+
+    dry_run = not args.apply
+    report = run_orphan_cleanup_once(
+        args.retention_days,
+        dry_run=dry_run,
+        uploads_dir=args.uploads_dir,
+    )
+
+    mode = "DRY RUN" if dry_run else "APPLY"
+    print(f"[{mode}] retention_days={report.retention_days}")
+    print("summary:")
+    for k, v in report.counts.items():
+        print(f"  - {k}: {v}")
+
+    if args.verbose:
+        if report.marked_missing:
+            print("\nwould_mark_missing_as_orphaned:")
+            for artifact_id in report.marked_missing:
+                print(f"  - {artifact_id}")
+        if report.hard_deleted_orphaned:
+            print("\nwould_hard_delete_orphaned:")
+            for artifact_id in report.hard_deleted_orphaned:
+                print(f"  - {artifact_id}")
+        if report.deleted_disk_only_dirs:
+            print("\nwould_delete_disk_only_dirs:")
+            for p in report.deleted_disk_only_dirs:
+                print(f"  - {p}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fair_platform/backend/jobs/__init__.py
+++ b/src/fair_platform/backend/jobs/__init__.py
@@ -1,0 +1,3 @@
+"""Background jobs for the backend."""
+
+__all__ = []

--- a/src/fair_platform/backend/jobs/orphan_cleanup.py
+++ b/src/fair_platform/backend/jobs/orphan_cleanup.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from fair_platform.backend.data.database import get_session
+from fair_platform.backend.data.models.artifact import Artifact, ArtifactStatus
+from fair_platform.backend.data.storage import storage
+from fair_platform.backend.services.artifact_manager import ArtifactManager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class CleanupReport:
+    retention_days: int
+    dry_run: bool
+    marked_missing: list[UUID] = field(default_factory=list)
+    hard_deleted_orphaned: list[UUID] = field(default_factory=list)
+    deleted_disk_only_dirs: list[str] = field(default_factory=list)
+
+    @property
+    def counts(self) -> dict[str, int]:
+        return {
+            "marked_missing": len(self.marked_missing),
+            "hard_deleted_orphaned": len(self.hard_deleted_orphaned),
+            "deleted_disk_only_dirs": len(self.deleted_disk_only_dirs),
+        }
+
+
+@contextmanager
+def _session_from_sessionmaker(sessionmaker) -> Iterator[Session]:
+    session: Session = sessionmaker()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def _iter_upload_uuid_dirs(uploads_dir: Path) -> Iterable[Path]:
+    if not uploads_dir.exists():
+        return []
+    for child in uploads_dir.iterdir():
+        if child.is_dir():
+            yield child
+
+
+def run_orphan_cleanup_once(
+    retention_days: int,
+    *,
+    dry_run: bool = False,
+    uploads_dir: Optional[Path] = None,
+    sessionmaker=None,
+) -> CleanupReport:
+    """Run a single orphan cleanup pass.
+
+    This function is the shared core used by:
+    - the periodic background job (in-process)
+    - the debugging/tooling script
+
+    It covers:
+    1) DB rows pointing to missing files -> mark as orphaned
+    2) orphaned rows older than retention -> hard delete from FS + remove from DB
+    3) disk-only UUID dirs under uploads/ with no DB row -> delete after retention
+
+    Args:
+        retention_days: Delete threshold in days (N).
+        dry_run: If True, only report actions; do not mutate DB or filesystem.
+        uploads_dir: Optional override for uploads directory.
+        sessionmaker: Optional SQLAlchemy sessionmaker for tests.
+
+    Returns:
+        CleanupReport
+    """
+
+    if retention_days < 0:
+        raise ValueError("retention_days must be >= 0")
+
+    effective_uploads_dir = Path(uploads_dir) if uploads_dir is not None else storage.uploads_dir
+
+    report = CleanupReport(retention_days=retention_days, dry_run=dry_run)
+
+    session_ctx = _session_from_sessionmaker(sessionmaker) if sessionmaker is not None else get_session()
+
+    # Keep cutoff logic consistent with ArtifactManager.cleanup_orphaned()
+    now = datetime.now()
+    cutoff_dt = now - timedelta(days=retention_days)
+    cutoff_ts = cutoff_dt.timestamp()
+
+    # Storage backend override so ArtifactManager deletes from the same uploads_dir we scan.
+    storage_backend = None
+    if uploads_dir is not None:
+        class _StorageBackend:
+            def __init__(self, uploads_dir: Path):
+                self.uploads_dir = uploads_dir
+
+        storage_backend = _StorageBackend(effective_uploads_dir)
+
+    with session_ctx as session:
+        # Build set of existing artifact IDs for FS->DB scan.
+        existing_ids = {row[0] for row in session.query(Artifact.id).all()}
+
+        # Phase 1: DB -> FS consistency (missing file => orphaned)
+        local_artifacts = (
+            session.query(Artifact)
+            .filter(Artifact.storage_type == "local")
+            .all()
+        )
+
+        for artifact in local_artifacts:
+            file_path = effective_uploads_dir / artifact.storage_path
+            if file_path.exists():
+                continue
+
+            # Only transition active artifacts to orphaned.
+            if artifact.status in (ArtifactStatus.archived, ArtifactStatus.orphaned):
+                continue
+
+            report.marked_missing.append(artifact.id)
+            if not dry_run:
+                artifact.status = ArtifactStatus.orphaned
+                artifact.updated_at = now
+                session.add(artifact)
+
+        # Phase 2: hard delete orphaned older than retention
+        orphaned_to_delete = (
+            session.query(Artifact)
+            .filter(
+                Artifact.status == ArtifactStatus.orphaned,
+                Artifact.updated_at < cutoff_dt,
+            )
+            .all()
+        )
+        report.hard_deleted_orphaned.extend(a.id for a in orphaned_to_delete)
+
+        if not dry_run and orphaned_to_delete:
+            manager = ArtifactManager(session, storage_backend=storage_backend)
+            manager.cleanup_orphaned(older_than_days=retention_days, hard_delete=True)
+
+        # Phase 3: FS -> DB consistency (disk-only UUID directories)
+        for uuid_dir in _iter_upload_uuid_dirs(effective_uploads_dir):
+            try:
+                dir_uuid = UUID(uuid_dir.name)
+            except Exception:
+                continue
+
+            if dir_uuid in existing_ids:
+                continue
+
+            try:
+                mtime = uuid_dir.stat().st_mtime
+            except FileNotFoundError:
+                continue
+
+            if mtime >= cutoff_ts:
+                continue
+
+            report.deleted_disk_only_dirs.append(str(uuid_dir))
+            if not dry_run:
+                shutil.rmtree(uuid_dir, ignore_errors=True)
+
+    return report
+
+
+async def orphan_cleanup_loop(
+    stop_event: asyncio.Event,
+    *,
+    interval_seconds: int,
+    retention_days: int,
+    dry_run: bool = False,
+) -> None:
+    """Periodic orphan cleanup loop.
+
+    Runs immediately once, then every interval_seconds until stop_event is set.
+    """
+
+    if interval_seconds <= 0:
+        raise ValueError("interval_seconds must be > 0")
+
+    while not stop_event.is_set():
+        try:
+            report = run_orphan_cleanup_once(retention_days, dry_run=dry_run)
+            logger.info(
+                "Orphan cleanup run finished (dry_run=%s): %s",
+                dry_run,
+                report.counts,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Orphan cleanup run failed")
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
+        except asyncio.TimeoutError:
+            continue

--- a/tests/test_orphan_cleanup_job.py
+++ b/tests/test_orphan_cleanup_job.py
@@ -1,0 +1,114 @@
+import os
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from fair_platform.backend.data.models.artifact import Artifact, ArtifactStatus
+from fair_platform.backend.jobs.orphan_cleanup import run_orphan_cleanup_once
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"test")
+
+
+def test_orphan_cleanup_dry_run_and_apply(test_db, tmp_path: Path):
+    uploads_dir = tmp_path / "uploads"
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+
+    now = datetime.now()
+
+    with test_db() as session:
+        # Artifact with missing file (should be marked orphaned)
+        missing_id = uuid4()
+        missing = Artifact(
+            id=missing_id,
+            title="missing",
+            artifact_type="file",
+            mime="text/plain",
+            storage_path=f"{missing_id}/missing.txt",
+            storage_type="local",
+            creator_id=uuid4(),
+            status=ArtifactStatus.attached,
+            access_level="private",
+            created_at=now,
+            updated_at=now,
+        )
+
+        # Old orphaned artifact with existing file (should be hard deleted)
+        old_id = uuid4()
+        old_date = now - timedelta(days=8)
+        old = Artifact(
+            id=old_id,
+            title="old",
+            artifact_type="file",
+            mime="text/plain",
+            storage_path=f"{old_id}/old.txt",
+            storage_type="local",
+            creator_id=uuid4(),
+            status=ArtifactStatus.orphaned,
+            access_level="private",
+            created_at=old_date,
+            updated_at=old_date,
+        )
+
+        session.add_all([missing, old])
+        session.commit()
+
+    # Create file for old orphaned artifact
+    _touch(uploads_dir / f"{old_id}" / "old.txt")
+
+    # Create disk-only orphan dir older than retention
+    disk_only_id = uuid4()
+    disk_only_dir = uploads_dir / str(disk_only_id)
+    disk_only_dir.mkdir(parents=True, exist_ok=True)
+    _touch(disk_only_dir / "x.bin")
+    old_ts = time.time() - (8 * 86400)
+    os.utime(disk_only_dir, (old_ts, old_ts))
+
+    # DRY RUN: should report actions but not change DB/FS
+    report = run_orphan_cleanup_once(
+        7,
+        dry_run=True,
+        uploads_dir=uploads_dir,
+        sessionmaker=test_db,
+    )
+
+    assert missing_id in report.marked_missing
+    assert old_id in report.hard_deleted_orphaned
+    assert str(disk_only_dir) in report.deleted_disk_only_dirs
+
+    with test_db() as session:
+        still_missing = session.get(Artifact, missing_id)
+        still_old = session.get(Artifact, old_id)
+        assert still_missing is not None
+        assert still_missing.status == ArtifactStatus.attached
+        assert still_old is not None
+
+    assert (uploads_dir / f"{old_id}" / "old.txt").exists()
+    assert disk_only_dir.exists()
+
+    # APPLY: should perform changes
+    report2 = run_orphan_cleanup_once(
+        7,
+        dry_run=False,
+        uploads_dir=uploads_dir,
+        sessionmaker=test_db,
+    )
+
+    assert missing_id in report2.marked_missing
+    assert old_id in report2.hard_deleted_orphaned
+    assert str(disk_only_dir) in report2.deleted_disk_only_dirs
+
+    with test_db() as session:
+        updated_missing = session.get(Artifact, missing_id)
+        deleted_old = session.get(Artifact, old_id)
+        assert updated_missing is not None
+        assert updated_missing.status == ArtifactStatus.orphaned
+        assert deleted_old is None
+
+    assert not (uploads_dir / f"{old_id}" / "old.txt").exists()
+    assert not disk_only_dir.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "fair-platform"
-version = "6.0.2"
+version = "6.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
### Summary
Adds an in-process background cleanup job for orphaned artifacts plus a small CLI script and tests. The job runs on a configurable interval, marks DB artifacts as orphaned when their local file is missing, hard-deletes orphaned artifacts older than a retention threshold, and removes disk-only stale UUID directories under uploads.

### Changes
- Background task wired into FastAPI lifespan (gated by `FAIR_ORPHAN_CLEANUP_ENABLED`)
  - Config:
    - `FAIR_ORPHAN_CLEANUP_INTERVAL_SECONDS` (default `3600`)
    - `FAIR_ORPHAN_CLEANUP_RETENTION_DAYS` (default `7`)
    - `FAIR_ORPHAN_CLEANUP_DRY_RUN`
- New job implementation: `run_orphan_cleanup_once()` + `orphan_cleanup_loop()`
  - Phase 1: DB → FS consistency (missing file → mark `orphaned`)
  - Phase 2: hard delete orphaned older than retention (delegates to `ArtifactManager.cleanup_orphaned(..., hard_delete=True)`)
  - Phase 3: FS → DB consistency (delete disk-only UUID dirs older than retention)
- New debug runner: `scripts/orphan_cleanup.py` (dry-run by default; `--apply` to execute)
- New tests validating dry-run vs apply behavior

### Logging
- Logs per-run counts via `logger.info(... report.counts)` and logs exceptions.

### Acceptance criteria gaps / TODO before merge
- Confirm/implement “respects artifacts with active submissions” (not explicitly enforced in new job code; needs verification or additional filtering + tests).
- “Manual admin endpoint for emergency cleanup” not added here (script exists, but endpoint requirement still needs to be confirmed/implemented).
- Decide whether default schedule should be **daily** (`86400s`) vs current default **hourly** (`3600s`).
- Consider enhancing metrics/logging (duration, scanned totals, config values) if required.

### Notes
- `uv.lock` modified (dependency lockfile update).