### PR TITLE
Fix #93: prepare submission schema and events table

### DIFF
--- a/src/fair_platform/backend/alembic/versions/20260131_0004_submission_events.py
+++ b/src/fair_platform/backend/alembic/versions/20260131_0004_submission_events.py
@@ -1,0 +1,79 @@
+"""Add draft/published fields to submissions and create submission_events table
+
+Revision ID: 20260131_0004
+Revises: 20251101_0003
+Create Date: 2026-01-31
+"""
+
+from __future__ import annotations
+
+from alembic import op  # type: ignore
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision = "20260131_0004"
+down_revision = "20251101_0003"
+branch_labels = None
+depends_on = None
+
+submissioneventtype = sa.Enum(
+    "AI_GRADED", "MANUAL_EDIT", "RETURNED_TO_STUDENT", name="submissioneventtype"
+)
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("submissions", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("draft_score", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("draft_feedback", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("published_score", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("published_feedback", sa.Text(), nullable=True))
+        batch_op.add_column(
+            sa.Column("returned_at", sa.TIMESTAMP(timezone=True), nullable=True)
+        )
+
+    submissioneventtype.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "submission_events",
+        sa.Column("id", sa.UUID(), primary_key=True, nullable=False),
+        sa.Column(
+            "submission_id",
+            sa.UUID(),
+            sa.ForeignKey("submissions.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("event_type", submissioneventtype, nullable=False),
+        sa.Column(
+            "actor_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "workflow_run_id",
+            sa.UUID(),
+            sa.ForeignKey("workflow_runs.id"),
+            nullable=True,
+        ),
+        sa.Column("details", JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("submission_events")
+
+    submissioneventtype.drop(op.get_bind(), checkfirst=True)
+
+    with op.batch_alter_table("submissions", schema=None) as batch_op:
+        batch_op.drop_column("returned_at")
+        batch_op.drop_column("published_feedback")
+        batch_op.drop_column("published_score")
+        batch_op.drop_column("draft_feedback")
+        batch_op.drop_column("draft_score")

--- a/src/fair_platform/backend/data/models/__init__.py
+++ b/src/fair_platform/backend/data/models/__init__.py
@@ -8,6 +8,7 @@ from .workflow_run import WorkflowRun, WorkflowRunStatus
 from .plugin import Plugin
 from .artifact import Artifact
 from .submission_result import SubmissionResult
+from .submission_event import SubmissionEvent, SubmissionEventType
 
 __all__ = [
     "User",
@@ -23,4 +24,6 @@ __all__ = [
     "Plugin",
     "Artifact",
     "SubmissionResult",
+    "SubmissionEvent",
+    "SubmissionEventType",
 ]

--- a/src/fair_platform/backend/data/models/submission.py
+++ b/src/fair_platform/backend/data/models/submission.py
@@ -1,6 +1,6 @@
 from uuid import UUID, uuid4
 from datetime import datetime
-from sqlalchemy import String, ForeignKey, UUID as SAUUID, TIMESTAMP, Table, Column
+from sqlalchemy import String, ForeignKey, UUID as SAUUID, TIMESTAMP, Table, Column, Float, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from enum import Enum
 from typing import Optional, List, TYPE_CHECKING
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from .workflow_run import WorkflowRun
     from .artifact import Artifact
     from .submission_result import SubmissionResult
+    from .submission_event import SubmissionEvent
     from .submitter import Submitter
     from .user import User
 
@@ -85,6 +86,13 @@ class Submission(Base):
     official_run_id: Mapped[Optional[UUID]] = mapped_column(
         SAUUID, ForeignKey("workflow_runs.id"), nullable=True
     )
+    draft_score: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    draft_feedback: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    published_score: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    published_feedback: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    returned_at: Mapped[Optional[datetime]] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
 
     assignment: Mapped["Assignment"] = relationship(
         "Assignment", back_populates="submissions"
@@ -116,6 +124,11 @@ class Submission(Base):
     # Processing results (per workflow run)
     results: Mapped[List["SubmissionResult"]] = relationship(
         "SubmissionResult",
+        back_populates="submission",
+        cascade="all, delete-orphan",
+    )
+    events: Mapped[List["SubmissionEvent"]] = relationship(
+        "SubmissionEvent",
         back_populates="submission",
         cascade="all, delete-orphan",
     )

--- a/src/fair_platform/backend/data/models/submission_event.py
+++ b/src/fair_platform/backend/data/models/submission_event.py
@@ -1,0 +1,55 @@
+from uuid import UUID, uuid4
+from datetime import datetime
+from enum import Enum
+from typing import Optional, TYPE_CHECKING
+
+from sqlalchemy import (
+    UUID as SAUUID,
+    ForeignKey,
+    TIMESTAMP,
+    Enum as SAEnum,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from ..database import Base
+
+if TYPE_CHECKING:
+    from .submission import Submission
+    from .user import User
+    from .workflow_run import WorkflowRun
+
+
+class SubmissionEventType(str, Enum):
+    AI_GRADED = "AI_GRADED"
+    MANUAL_EDIT = "MANUAL_EDIT"
+    RETURNED_TO_STUDENT = "RETURNED_TO_STUDENT"
+
+
+class SubmissionEvent(Base):
+    __tablename__ = "submission_events"
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    submission_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("submissions.id", ondelete="CASCADE"), nullable=False
+    )
+    event_type: Mapped[SubmissionEventType] = mapped_column(
+        SAEnum(SubmissionEventType, name="submissioneventtype"), nullable=False
+    )
+    actor_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("users.id"), nullable=True
+    )
+    workflow_run_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("workflow_runs.id"), nullable=True
+    )
+    details: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    submission: Mapped["Submission"] = relationship(
+        "Submission", back_populates="events"
+    )
+    actor: Mapped[Optional["User"]] = relationship("User")
+    workflow_run: Mapped[Optional["WorkflowRun"]] = relationship("WorkflowRun")


### PR DESCRIPTION

This PR prepares the database for the new submission architecture by:
- Adding draft and published score/feedback fields to Submission
- Adding returned_at timestamp to Submission
- Introducing SubmissionEvent model for event-based submission history
- Including an Alembic migration for all schema changes

This change is schema-only and does not modify existing behavior.
