### PR TITLE
feat: add state injection

### DIFF
--- a/frontend-dev/src/contexts/auth-context.tsx
+++ b/frontend-dev/src/contexts/auth-context.tsx
@@ -1,5 +1,6 @@
 import React, {createContext, useCallback, useContext, useEffect, useMemo, useState} from "react";
 import api from "@/lib/api";
+import { getOptionalInitialState } from "@/lib/initial-state";
 
 export enum AuthUserRole {
   USER = 'user',
@@ -60,15 +61,54 @@ const normalizeUser = (raw: Partial<AuthUser> & { role?: string, isVerified?: bo
 })
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const [user, setUser] = useState<AuthUser | null>(null)
-  const [token, setToken] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
+  const injectedState = useMemo(() => getOptionalInitialState(), [])
+  const injectedUser = useMemo(
+    () => (injectedState?.auth.user ? normalizeUser(injectedState.auth.user) : null),
+    [injectedState],
+  )
+  const injectedIsAuthenticated = useMemo(
+    () => Boolean(injectedState?.auth.isAuthenticated && injectedUser),
+    [injectedState, injectedUser],
+  )
+  const [user, setUser] = useState<AuthUser | null>(() => {
+    if (injectedIsAuthenticated && injectedUser) {
+      return injectedUser
+    }
+    if (typeof window !== 'undefined') {
+      const raw = localStorage.getItem('user')
+      if (raw) {
+        try {
+          return normalizeUser(JSON.parse(raw))
+        } catch {
+          return null
+        }
+      }
+    }
+    return null
+  })
+  const [token, setToken] = useState<string | null>(() => {
+    if (injectedIsAuthenticated) {
+      return "injected-session"
+    }
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('token')
+    }
+    return null
+  })
+  const [loading, setLoading] = useState(!injectedIsAuthenticated)
 
   useEffect(() => {
     const validateStoredSession = async () => {
       try {
         const storedToken = typeof window !== 'undefined' ? localStorage.getItem('token') : null
         const storedUser = typeof window !== 'undefined' ? localStorage.getItem('user') : null
+
+        if (!storedToken && injectedIsAuthenticated && injectedUser) {
+          setToken('injected-session')
+          setUser(injectedUser)
+          persist(null, injectedUser)
+          return
+        }
         
         if (storedToken && storedUser) {
           // Set the token temporarily to make the validation request
@@ -119,7 +159,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         window.removeEventListener('auth:session-expired', handleSessionExpiry)
       }
     }
-  }, [])
+  }, [injectedIsAuthenticated, injectedUser])
 
   const persist = useCallback((nextToken: string | null, nextUser: AuthUser | null) => {
     if (typeof window === 'undefined') return
@@ -192,6 +232,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     setToken(null)
     setUser(null)
     persist(null, null)
+    void api.post('/auth/logout').catch(() => undefined)
   }, [persist])
 
   const setSession = useCallback((newToken: string, rawUser: Partial<AuthUser> & { role?: string, isVerified?: boolean, is_verified?: boolean }) => {

--- a/frontend-dev/src/lib/initial-state.ts
+++ b/frontend-dev/src/lib/initial-state.ts
@@ -1,0 +1,51 @@
+import type { AuthUser } from "@/contexts/auth-context";
+
+export interface FairInitialState {
+  auth: {
+    isAuthenticated: boolean;
+    user: AuthUser | null;
+  };
+  features: {
+    emailEnabled: boolean;
+    enforceEmailVerification: boolean;
+  };
+  platform: {
+    deploymentMode: "COMMUNITY" | "ENTERPRISE";
+    baseUrl: string;
+  };
+  injectedAt: string;
+}
+
+const SCRIPT_ID = "__FAIR_INITIAL_STATE__";
+
+export function getInitialState(): FairInitialState {
+  if (typeof document === "undefined") {
+    throw new Error("Initial state is only available in browser context.");
+  }
+
+  const script = document.getElementById(SCRIPT_ID);
+  if (!script || script.textContent === null) {
+    throw new Error("Initial state not found in document.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(script.textContent);
+  } catch {
+    throw new Error("Initial state JSON is invalid.");
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Initial state has invalid shape.");
+  }
+
+  return parsed as FairInitialState;
+}
+
+export function getOptionalInitialState(): FairInitialState | null {
+  try {
+    return getInitialState();
+  } catch {
+    return null;
+  }
+}

--- a/frontend-dev/src/providers.tsx
+++ b/frontend-dev/src/providers.tsx
@@ -2,7 +2,7 @@ import {QueryClientProvider} from "@tanstack/react-query";
 import {queryClient} from "@/lib/query-client";
 import {AuthProvider} from "@/contexts/auth-context";
 import {ThemeProvider} from "@/components/theme-provider"
-import {ReactNode, useEffect} from "react";
+import {ReactNode, useEffect, useMemo} from "react";
 import {SessionSocketProvider} from "@/contexts/session-socket-context";
 import {useVersionCheck} from "@/hooks/use-version";
 import { useTheme } from "@/components/theme-provider";
@@ -11,6 +11,7 @@ import { useLocalPreference } from "@/hooks/use-local-preference";
 import { useUserSetting } from "@/hooks/use-user-settings";
 import type { LanguageCode, ThemeMode } from "@/hooks/use-preference-settings";
 import api from "@/lib/api";
+import { getOptionalInitialState } from "@/lib/initial-state";
 
 
 function VersionChecker() {
@@ -21,6 +22,8 @@ function VersionChecker() {
 function SettingsRuntime() {
   const { theme, setTheme } = useTheme();
   const { i18n } = useTranslation();
+  const initialState = useMemo(() => getOptionalInitialState(), []);
+  const injectedEmailEnabled = initialState?.features?.emailEnabled;
 
   const { value: localTheme, setValue: setLocalTheme } =
     useLocalPreference<ThemeMode | undefined>("ui.theme");
@@ -88,6 +91,11 @@ function SettingsRuntime() {
   }, [resolvedDevMode]);
 
   useEffect(() => {
+    if (typeof injectedEmailEnabled === "boolean") {
+      setLocalEmailEnabled(injectedEmailEnabled);
+      return;
+    }
+
     let active = true;
     const loadSystemConfig = async () => {
       try {
@@ -104,7 +112,7 @@ function SettingsRuntime() {
     return () => {
       active = false;
     };
-  }, [setLocalEmailEnabled]);
+  }, [injectedEmailEnabled, setLocalEmailEnabled]);
 
   return null;
 }

--- a/specs/state-injection.md
+++ b/specs/state-injection.md
@@ -1,0 +1,432 @@
+# State Injection Specification
+
+## Overview
+
+This specification defines a system for injecting initial application state into the frontend SPA via a global `window.__FAIR_INITIAL_STATE__` object. This eliminates redundant API calls during app initialization and improves perceived performance by reducing loader spinners and cascading network requests.
+
+## Problem Statement
+
+Currently, the frontend must make multiple API calls after loading to determine:
+- Whether the user is authenticated
+- User identity, role, and capabilities
+- Feature availability (e.g., email enabled, email verification enforcement)
+- Platform deployment mode
+
+This results in:
+- Unnecessary delays before UI can be properly rendered
+- Multiple loading states (initial auth check, system config check)
+- Potential for race conditions between dependent requests
+- Worse perceived performance
+
+## Solution: Window State Injection
+
+The backend will inject a JSON object into the HTML template before serving the SPA, containing all necessary initial state. This data is computed server-side once and included in the initial HTTP response.
+
+## Architecture
+
+### State Injection Pipeline (Production Only)
+
+**Note**: State injection is a **production-only feature** enabled by `fair serve`. In development mode (`fair dev`), the frontend makes normal API calls. This keeps the dev setup simple and avoids unnecessary complexity.
+
+```
+Production Request to / (FastAPI Handler)
+    ↓
+    ├─ User authentication check (via JWT cookie or unauthenticated state)
+    ├─ User capabilities computation (from role + deployment mode)
+    ├─ System features fetch (email_enabled, enforce_email_verification, etc.)
+    ├─ Platform config fetch (deployment mode, base_url, etc.)
+    ↓
+    └─→ Render HTML with <script id="__FAIR_INITIAL_STATE__" type="application/json">
+         {state object}
+         </script>
+    ↓
+React App Bootstrap (Production)
+    ↓
+    ├─ Hydrate from window.__FAIR_INITIAL_STATE__
+    ├─ Initialize Zustand store with injected state
+    ├─ Skip redundant /api/auth/me and /api/v1/system/config calls
+    ↓
+    └─→ Render UI with instant knowledge of auth/features
+```
+
+### Where Injection Happens
+
+**Production Mode** (`fair serve`): The backend's SPA fallback middleware in `main.py` serves `index.html` with injected state.
+
+- A route handler intercepts requests to `/` (the SPA entry point)
+- Loads the `index.html` template from dist
+- Injects state into it via a `<script>` tag
+- Returns the modified HTML with `Cache-Control: no-cache` headers
+
+**Development Mode** (`fair dev`): No state injection. The frontend calls API endpoints normally.
+
+### State Structure
+
+```typescript
+interface FairInitialState {
+  // Authentication & User
+  auth: {
+    isAuthenticated: boolean;
+    user: {
+      id: string;           // UUID
+      name: string;
+      email: string;
+      role: "admin" | "instructor" | "user";
+      capabilities: string[];  // e.g., ["admin", "create_course", ...]
+      settings: Record<string, unknown>;  // User settings (camelCase)
+      isVerified: boolean;
+    } | null;
+    // Future: token refresh metadata if needed
+  };
+
+  // Platform Features & Configuration
+  features: {
+    emailEnabled: boolean;
+    enforceEmailVerification: boolean;
+    // Future: other feature flags
+  };
+
+  // Platform Configuration
+  platform: {
+    deploymentMode: "COMMUNITY" | "ENTERPRISE";
+    baseUrl: string;  // e.g., "http://localhost:3000"
+    // Future: version, etc.
+  };
+
+  // Timestamp for debugging/cache invalidation
+  injectedAt: string;  // ISO 8601 timestamp
+}
+```
+
+## Implementation
+
+### Backend Changes
+
+#### 1. New Helper Module: `src/fair_platform/backend/core/state_injection.py`
+
+```python
+from datetime import datetime, timezone
+from typing import Optional
+from fair_platform.backend.data.models import User
+from fair_platform.backend.core.config import (
+    get_deployment_mode,
+    get_email_enabled,
+    get_enforce_email_verification,
+    get_base_url,
+)
+from fair_platform.backend.core.security.permissions import auth_user_payload
+
+def build_initial_state(user: Optional[User] = None) -> dict:
+    """
+    Build the initial state object to be injected into the frontend.
+    
+    Args:
+        user: The authenticated User model, or None if unauthenticated.
+    
+    Returns:
+        A dict representing FairInitialState.
+    """
+    auth_user = None
+    if user:
+        auth_user = auth_user_payload(user)
+        # Convert settings to camelCase (already handled in auth_user_payload)
+    
+    return {
+        "auth": {
+            "isAuthenticated": user is not None,
+            "user": auth_user,
+        },
+        "features": {
+            "emailEnabled": get_email_enabled(),
+            "enforceEmailVerification": get_enforce_email_verification(),
+        },
+        "platform": {
+            "deploymentMode": get_deployment_mode(),
+            "baseUrl": get_base_url(),
+        },
+        "injectedAt": datetime.now(timezone.utc).isoformat(),
+    }
+```
+
+#### 2. Modify `src/fair_platform/backend/main.py`
+
+In the `run()` function, wrap the SPA serving logic to inject state:
+
+```python
+import json
+from fair_platform.backend.core.state_injection import build_initial_state
+
+def run(host: str = "127.0.0.1", port: int = 8000, headless: bool = False, dev: bool = False):
+    if not headless and not dev:  # State injection only in production (fair serve)
+        frontend_files = importlib.resources.files("fair_platform.frontend")
+        dist_dir = frontend_files / "dist"
+
+        with importlib.resources.as_file(dist_dir) as dist_path:
+            # ... existing static file mounts ...
+            
+            # Read the index.html template once at startup
+            index_path = dist_path / "index.html"
+            with open(index_path, 'r', encoding='utf-8') as f:
+                index_template = f.read()
+            
+            @app.get("/", include_in_schema=False)
+            async def serve_index(request: Request):
+                """
+                Serve index.html with injected initial state (production only).
+                For authenticated requests, extract the user from the JWT token.
+                """
+                user = None
+                token = request.cookies.get("access_token")
+                if token:
+                    try:
+                        # Decode token and fetch user from DB
+                        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+                        user_id = payload.get("sub")
+                        if user_id:
+                            db = SessionLocal()
+                            try:
+                                user = db.get(User, UUID(user_id))
+                            finally:
+                                db.close()
+                    except (JWTError, Exception):
+                        # Invalid token; user remains None
+                        pass
+                
+                initial_state = build_initial_state(user)
+                state_json = json.dumps(initial_state)
+                
+                # Inject state into HTML
+                html = index_template.replace(
+                    '</head>',
+                    f'<script id="__FAIR_INITIAL_STATE__" type="application/json">{state_json}</script>\n</head>'
+                )
+                
+                return HTMLResponse(
+                    content=html,
+                    headers={"Cache-Control": "no-cache, no-store, must-revalidate"}
+                )
+    
+    elif dev:  # Development mode: no state injection, normal SPA serving
+        # State injection is skipped; frontend makes normal API calls
+        pass
+```
+
+#### 3. Necessary Imports
+
+Add to `main.py`:
+```python
+from fastapi import Request
+from fastapi.responses import HTMLResponse
+from jose import jwt, JWTError
+from fair_platform.backend.data.models import User
+from fair_platform.backend.core.state_injection import build_initial_state
+from uuid import UUID
+```
+
+### Frontend Changes
+
+#### 1. Create `frontend-dev/src/lib/initial-state.ts`
+
+```typescript
+export interface FairInitialState {
+  auth: {
+    isAuthenticated: boolean;
+    user: {
+      id: string;
+      name: string;
+      email: string;
+      role: "admin" | "instructor" | "user";
+      capabilities: string[];
+      settings: Record<string, unknown>;
+      isVerified: boolean;
+    } | null;
+  };
+  features: {
+    emailEnabled: boolean;
+    enforceEmailVerification: boolean;
+  };
+  platform: {
+    deploymentMode: "COMMUNITY" | "ENTERPRISE";
+    baseUrl: string;
+  };
+  injectedAt: string;
+}
+
+export function getInitialState(): FairInitialState {
+  const script = document.getElementById("__FAIR_INITIAL_STATE__");
+  
+  if (!script || script.textContent === null) {
+    throw new Error("Initial state not found in HTML. This may indicate a server-side rendering error.");
+  }
+  
+  try {
+    return JSON.parse(script.textContent);
+  } catch (error) {
+    console.error("Failed to parse initial state:", error);
+    throw new Error("Failed to parse initial state from server.");
+  }
+}
+```
+
+#### 2. Update Zustand Auth Store
+
+In `frontend-dev/src/stores/auth-store.ts` (or similar), initialize from injected state:
+
+```typescript
+import { getInitialState } from "@/lib/initial-state";
+
+interface AuthState {
+  user: FairInitialState["auth"]["user"];
+  isAuthenticated: boolean;
+  // ... other fields
+}
+
+const initialState = getInitialState();
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: initialState.auth.user,
+  isAuthenticated: initialState.auth.isAuthenticated,
+  // ... other store methods
+}));
+```
+
+#### 3. Update System/Features Store
+
+In `frontend-dev/src/stores/system-store.ts`:
+
+```typescript
+import { getInitialState } from "@/lib/initial-state";
+
+const initialState = getInitialState();
+
+export const useSystemStore = create<SystemState>((set) => ({
+  features: initialState.features,
+  platform: initialState.platform,
+  // ... other store methods
+}));
+```
+
+#### 4. Skip Redundant API Calls
+
+In initialization code (e.g., app middleware or `main.tsx`), remove or guard:
+- Calls to `GET /api/auth/me` on app load (if user is already in store)
+- Calls to `GET /api/v1/system/config` on app load
+
+Example guard in a hook:
+```typescript
+export function useInitializeAuth() {
+  const { user, isAuthenticated } = useAuthStore();
+  
+  // Only fetch if not already initialized from injected state
+  if (isAuthenticated && user) {
+    return; // Skip API call
+  }
+  
+  // Otherwise, fetch /api/auth/me
+  // ...
+}
+```
+
+## Security Considerations
+
+### 1. JWT Token in Cookie vs. State Injection
+
+- The injected state is computed server-side before response rendering
+- User data is derived from the JWT token (if present in cookie or header)
+- The injected JSON is part of the HTML; it is **not** secret and **not** a security boundary
+- The actual JWT token remains in the cookie (HttpOnly, Secure flags) and is used for subsequent API requests
+
+### 2. No Sensitive Data in Injected State
+
+- **Do not** inject passwords, secret tokens, or API keys
+- Current approach is safe: only public user info (name, email, role, capabilities) is included
+- Settings field should be validated to ensure no sensitive data
+
+### 3. Tampering Risk
+
+- Browser-resident state can be modified by users/scripts
+- Injected state is **informational**; authorization is enforced server-side on each API request
+- Backend must always re-validate permissions on writes
+- This is identical to the current threat model (localStorage, sessionStorage, etc.)
+
+## Development Mode
+
+In development mode (`fair dev`), state injection is **not applied**. The frontend's bun dev server runs independently (port 3000), and the backend runs on port 8000. The frontend makes normal API calls to:
+- `GET /api/auth/me` for auth info
+- `GET /api/v1/system/config` for platform features
+
+This keeps the dev experience simple and avoids the complexity of injecting state at build time or modifying the dev server setup. State injection only kicks in when running `fair serve` in production.
+
+## Migration Path
+
+### Phase 1: Implement Injection (No Breaking Changes)
+
+- Add `build_initial_state()` function
+- Add state injection middleware to backend
+- Frontend reads from injected state if available, falls back to API calls
+- Both code paths coexist; no changes required to existing components
+
+### Phase 2: Adopt in Components
+
+- Update stores to hydrate from injected state
+- Gradually remove redundant API calls
+- Test thoroughly to ensure no regressions
+
+## Extensibility
+
+Future state fields can be added to `FairInitialState`:
+
+```typescript
+export interface FairInitialState {
+  // ... existing fields ...
+  workspace?: {
+    id: string;
+    name: string;
+    // ...
+  };
+  theme?: {
+    mode: "light" | "dark";
+    // ...
+  };
+  experiments?: {
+    // Feature flags, A/B tests
+  };
+}
+```
+
+Backend implementation in `build_initial_state()` would simply add the new fields.
+
+## Testing
+
+### Backend Tests
+
+- Unit test `build_initial_state(user=None)` with and without a user
+- Unit test state injection middleware with mock users
+- Integration test: verify HTML contains valid JSON in the injected script tag
+
+### Frontend Tests
+
+- Unit test `getInitialState()` parsing
+- Unit test store initialization from injected state
+- Integration test: verify stores are hydrated without API calls during app boot
+
+## Rollout Checklist
+
+- [ ] Implement `build_initial_state()` in backend
+- [ ] Update `main.py` to serve index with injected state
+- [ ] Test backend state injection in isolation
+- [ ] Implement `getInitialState()` helper in frontend
+- [ ] Update auth and system stores to read from injected state
+- [ ] Test frontend hydration without API calls
+- [ ] Update vite dev server config for proxy (if needed)
+- [ ] Remove or guard redundant API calls
+- [ ] Remove loading states for auth/system info
+- [ ] Test e2e: app boots without /api/auth/me and /api/v1/system/config calls
+- [ ] Deploy to production and monitor
+
+## Future Enhancements
+
+- Extend injected state with additional runtime features (theme, locale, workspace info)
+- Cache invalidation strategy (e.g., set state expiry in headers for browser/CDN caching)
+- Integration with analytics (track which features are enabled per deployment)
+- Support for custom state fields per deployment via environment variables

--- a/src/fair_platform/backend/api/routers/auth.py
+++ b/src/fair_platform/backend/api/routers/auth.py
@@ -4,7 +4,7 @@ from secrets import token_urlsafe
 from uuid import UUID, uuid4
 
 from fair_platform.backend.api.schema.user import AuthUserRead, UserCreate
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jose import jwt, JWTError
 import bcrypt
@@ -91,6 +91,48 @@ def create_access_token(data: dict, remember_me: bool = False):
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
 
+def _token_expiration_delta(remember_me: bool) -> timedelta:
+    if remember_me:
+        return timedelta(days=REMEMBER_ME_TOKEN_EXPIRE_DAYS)
+    return timedelta(hours=DEFAULT_TOKEN_EXPIRE_HOURS)
+
+
+def _set_access_token_cookie(response: Response, token: str, *, remember_me: bool) -> None:
+    is_secure = get_base_url().lower().startswith("https://")
+    max_age = int(_token_expiration_delta(remember_me).total_seconds())
+    response.set_cookie(
+        key="access_token",
+        value=token,
+        httponly=True,
+        secure=is_secure,
+        samesite="lax",
+        max_age=max_age,
+        path="/",
+    )
+
+
+def _set_access_token_cookie_from_token(response: Response, token: str) -> None:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        exp = payload.get("exp")
+        if isinstance(exp, (int, float)):
+            ttl_seconds = max(0, int(exp - datetime.now(timezone.utc).timestamp()))
+            is_secure = get_base_url().lower().startswith("https://")
+            response.set_cookie(
+                key="access_token",
+                value=token,
+                httponly=True,
+                secure=is_secure,
+                samesite="lax",
+                max_age=ttl_seconds,
+                path="/",
+            )
+            return
+    except JWTError:
+        pass
+    _set_access_token_cookie(response, token, remember_me=False)
+
+
 def _create_action_token(
     *,
     user: User,
@@ -175,6 +217,7 @@ async def register(
     user_in: UserCreate,
     db: Session = Depends(session_dependency),
     mailer: Mailer = Depends(get_mailer),
+    response: Response = None,
 ):
     """Register a new user with password hashing"""
     existing = db.query(User).filter(User.email == user_in.email).first()
@@ -215,6 +258,8 @@ async def register(
         {"sub": str(user.id), "role": user.role},
         remember_me=False
     )
+    if response is not None:
+        _set_access_token_cookie(response, access_token, remember_me=False)
     auth_user = auth_user_payload(user)
     auth_user["settings"] = to_camel_keys(auth_user.get("settings", {}))
     return {
@@ -228,6 +273,7 @@ async def register(
 def login(
     form_data: OAuth2PasswordRequestForm = Depends(),
     db: Session = Depends(session_dependency),
+    response: Response = None,
 ):
     """Login endpoint with proper password verification"""
     user = db.query(User).filter(User.email == form_data.username).first()
@@ -249,17 +295,30 @@ def login(
         {"sub": str(user.id), "role": user.role},
         remember_me=remember_me
     )
+    if response is not None:
+        _set_access_token_cookie(response, access_token, remember_me=remember_me)
     return {"access_token": access_token, "token_type": "bearer"}
 
 
 @router.get("/me", response_model=AuthUserRead)
-def read_me(current_user: User = Depends(get_current_user)):
+def read_me(
+    response: Response,
+    token: str = Depends(oauth2_scheme),
+    current_user: User = Depends(get_current_user),
+):
     """
     Return the currently authenticated user's public information.
     """
+    _set_access_token_cookie_from_token(response, token)
     auth_user = auth_user_payload(current_user)
     auth_user["settings"] = to_camel_keys(auth_user.get("settings", {}))
     return auth_user
+
+
+@router.post("/logout")
+def logout(response: Response):
+    response.delete_cookie("access_token", path="/")
+    return {"detail": "Logged out"}
 
 
 @router.post("/forgot-password")
@@ -345,6 +404,7 @@ async def resend_verification_request(
 async def verify_email_confirm(
     payload: TokenConfirmRequest,
     db: Session = Depends(session_dependency),
+    response: Response = None,
 ):
     token_data = _decode_action_token(
         payload.token,
@@ -369,6 +429,8 @@ async def verify_email_confirm(
         {"sub": str(user.id), "role": user.role},
         remember_me=False
     )
+    if response is not None:
+        _set_access_token_cookie(response, access_token, remember_me=False)
     auth_user = auth_user_payload(user)
     auth_user["settings"] = to_camel_keys(auth_user.get("settings", {}))
 

--- a/src/fair_platform/backend/core/state_injection.py
+++ b/src/fair_platform/backend/core/state_injection.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi.encoders import jsonable_encoder
+
+from fair_platform.backend.api.schema.casing import to_camel_keys
+from fair_platform.backend.core.config import (
+    get_base_url,
+    get_deployment_mode,
+    get_email_enabled,
+    get_enforce_email_verification,
+)
+from fair_platform.backend.core.security.permissions import auth_user_payload
+from fair_platform.backend.data.models.user import User
+
+
+def build_initial_state(user: User | None = None) -> dict[str, Any]:
+    auth_user: dict[str, Any] | None = None
+    if user is not None:
+        auth_user = jsonable_encoder(to_camel_keys(auth_user_payload(user)))
+
+    return {
+        "auth": {
+            "isAuthenticated": user is not None,
+            "user": auth_user,
+        },
+        "features": {
+            "emailEnabled": get_email_enabled(),
+            "enforceEmailVerification": get_enforce_email_verification(),
+        },
+        "platform": {
+            "deploymentMode": get_deployment_mode(),
+            "baseUrl": get_base_url(),
+        },
+        "injectedAt": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+__all__ = ["build_initial_state"]

--- a/src/fair_platform/backend/main.py
+++ b/src/fair_platform/backend/main.py
@@ -3,11 +3,14 @@ import os
 import logging
 import asyncio
 import sys
-from fastapi import FastAPI
+import json
+from uuid import UUID
+from fastapi import FastAPI, Request
 from contextlib import asynccontextmanager
 
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
+from jose import JWTError, jwt
 from starlette.middleware.cors import CORSMiddleware
 
 from fair_platform.backend.data.database import init_db
@@ -39,12 +42,34 @@ from fair_platform.backend.services.workflow_runner import (
 )
 from fair_platform.backend.data.database import SessionLocal
 from fair_platform.backend.data.models import ExtensionClient
+from fair_platform.backend.data.models.user import User
 from fair_platform.backend.services.extension_auth import hash_extension_secret
+from fair_platform.backend.api.routers.auth import ALGORITHM, SECRET_KEY
+from fair_platform.backend.core.state_injection import build_initial_state
 
 logger = logging.getLogger(__name__)
 
 CORE_EXTENSION_ID = "fair.core"
 CORE_EXTENSION_SECRET = "fair-core-dev-secret"
+
+
+def _serialize_initial_state_for_html(state: dict[str, object]) -> str:
+    serialized = json.dumps(state, separators=(",", ":"), ensure_ascii=False)
+    return (
+        serialized
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+
+def _inject_initial_state(index_template: str, state: dict[str, object]) -> str:
+    state_json = _serialize_initial_state_for_html(state)
+    state_script = (
+        '<script id="__FAIR_INITIAL_STATE__" type="application/json">'
+        f"{state_json}</script>"
+    )
+    return index_template.replace("</head>", f"{state_script}\n</head>", 1)
 
 
 def _is_auto_migrate_enabled() -> bool:
@@ -254,15 +279,56 @@ def run(
                 "/fonts", StaticFiles(directory=dist_path / "fonts"), name="fonts"
             )
             app.mount("/data", StaticFiles(directory=dist_path / "data"), name="data")
+            index_path = dist_path / "index.html"
+            index_template = index_path.read_text(encoding="utf-8")
 
         @app.get("/favicon.svg")
         async def favicon():
             return FileResponse(dist_path / "favicon.svg", media_type="image/svg+xml")
 
+        def _resolve_authenticated_user(request: Request) -> User | None:
+            auth_header = request.headers.get("Authorization", "").strip()
+            bearer_token: str | None = None
+            if auth_header.lower().startswith("bearer "):
+                bearer_token = auth_header[7:].strip() or None
+            token = bearer_token or request.cookies.get("access_token")
+            if not token:
+                return None
+
+            try:
+                payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+                user_id = payload.get("sub")
+                if not user_id:
+                    return None
+                with SessionLocal() as db:
+                    return db.get(User, UUID(str(user_id)))
+            except (JWTError, ValueError, TypeError):
+                return None
+
+        def _render_index_html_with_state(request: Request) -> str:
+            user = _resolve_authenticated_user(request)
+            return _inject_initial_state(index_template, build_initial_state(user))
+
+        @app.get("/", include_in_schema=False)
+        async def serve_index(request: Request):
+            if dev:
+                return FileResponse(dist_path / "index.html")
+            return HTMLResponse(
+                content=_render_index_html_with_state(request),
+                headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
+            )
+
         @app.middleware("http")
         async def spa_fallback(request, call_next):
             response = await call_next(request)
-            if response.status_code == 404:
+            if response.status_code == 404 and request.method == "GET":
+                if dev:
+                    return FileResponse(dist_path / "index.html")
+                return HTMLResponse(
+                    content=_render_index_html_with_state(request),
+                    headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
+                )
+            if response.status_code == 405 and request.method == "HEAD":
                 return FileResponse(dist_path / "index.html")
             return response
 

--- a/tests/test_auth_integration.py
+++ b/tests/test_auth_integration.py
@@ -452,6 +452,39 @@ class TestAuthenticationFlow:
             data={"username": email, "password": password},
         )
         assert login_response.status_code == 200
+        assert login_response.cookies.get("access_token")
+
+    def test_auth_me_sets_access_token_cookie_when_called_with_bearer(
+        self, test_client: TestClient, test_db, monkeypatch
+    ):
+        monkeypatch.setenv("FAIR_EMAIL_ENABLED", "0")
+        email = f"me-cookie-{uuid4()}@test.com"
+        password = "test_password_123"
+        with test_db() as session:
+            user = User(
+                id=uuid4(),
+                name="Cookie Sync User",
+                email=email,
+                role=UserRole.user.value,
+                password_hash=hash_password(password),
+                is_verified=True,
+            )
+            session.add(user)
+            session.commit()
+
+        login_response = test_client.post(
+            "/api/auth/login",
+            data={"username": email, "password": password},
+        )
+        assert login_response.status_code == 200
+        token = login_response.json()["access_token"]
+
+        me_response = test_client.get(
+            "/api/auth/me",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert me_response.status_code == 200
+        assert me_response.cookies.get("access_token")
 
     def test_login_succeeds_after_verify_when_enforced(
         self, test_client: TestClient, test_db, monkeypatch
@@ -668,6 +701,14 @@ class TestAuthenticationFlow:
         )
         assert me_response.status_code == 200
         assert me_response.json()["email"] == user.email
+        assert verify_response.cookies.get("access_token")
+
+    def test_logout_clears_access_token_cookie(self, test_client: TestClient):
+        response = test_client.post("/api/auth/logout")
+        assert response.status_code == 200
+        assert response.json()["detail"] == "Logged out"
+        set_cookie = response.headers.get("set-cookie", "")
+        assert "access_token=" in set_cookie
 
     def test_reset_password_confirm_updates_password_hash(self, test_client: TestClient, test_db):
         email = f"reset-{uuid4()}@test.com"

--- a/tests/test_backend_startup_migrations.py
+++ b/tests/test_backend_startup_migrations.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 
 import fair_platform.backend.main as backend_main
 
@@ -113,3 +114,21 @@ async def test_lifespan_warns_when_no_migration_and_no_fallback(monkeypatch):
         pass
 
     assert calls == ["warn"]
+
+
+def test_serialize_initial_state_for_html_escapes_html_sensitive_chars():
+    state = {"message": "<script>alert('xss')</script>&ok>"}
+    serialized = backend_main._serialize_initial_state_for_html(state)
+    assert "<script>" not in serialized
+    assert "\\u003cscript\\u003e" in serialized
+    assert "\\u0026ok\\u003e" in serialized
+    assert json.loads(serialized) == state
+
+
+def test_inject_initial_state_adds_script_before_head_close():
+    html = "<html><head><title>X</title></head><body></body></html>"
+    state = {"auth": {"isAuthenticated": False, "user": None}}
+    injected = backend_main._inject_initial_state(html, state)
+    assert "__FAIR_INITIAL_STATE__" in injected
+    assert injected.index("__FAIR_INITIAL_STATE__") < injected.index("</head>")
+    assert "</script>" in injected

--- a/tests/test_state_injection.py
+++ b/tests/test_state_injection.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from uuid import uuid4
+
+import fair_platform.backend.core.config as config
+from fair_platform.backend.core.state_injection import build_initial_state
+from fair_platform.backend.data.models.user import User, UserRole
+
+
+def test_build_initial_state_unauthenticated(monkeypatch):
+    monkeypatch.setenv("FAIR_EMAIL_ENABLED", "0")
+    monkeypatch.setenv("FAIR_ENFORCE_EMAIL_VERIFICATION", "1")
+    monkeypatch.setenv("FAIR_DEPLOYMENT_MODE", "COMMUNITY")
+    monkeypatch.setenv("FAIR_BASE_URL", "http://localhost:3000")
+    monkeypatch.delenv("FAIR_RESEND_API_KEY", raising=False)
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    monkeypatch.setattr(config, "RESEND_API_KEY", None)
+    monkeypatch.setattr(config, "EMAIL_ENABLED", False)
+
+    state = build_initial_state(None)
+    assert state["auth"]["isAuthenticated"] is False
+    assert state["auth"]["user"] is None
+    assert state["features"]["emailEnabled"] is False
+    assert state["features"]["enforceEmailVerification"] is False
+    assert state["platform"]["deploymentMode"] == "COMMUNITY"
+    assert state["platform"]["baseUrl"] == "http://localhost:3000"
+    assert datetime.fromisoformat(state["injectedAt"])
+
+
+def test_build_initial_state_authenticated_user(monkeypatch):
+    monkeypatch.setenv("FAIR_EMAIL_ENABLED", "1")
+    monkeypatch.setenv("FAIR_ENFORCE_EMAIL_VERIFICATION", "1")
+    monkeypatch.setenv("FAIR_DEPLOYMENT_MODE", "ENTERPRISE")
+    monkeypatch.setenv("FAIR_BASE_URL", "https://fair.example.com")
+    monkeypatch.delenv("FAIR_RESEND_API_KEY", raising=False)
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    monkeypatch.setattr(config, "RESEND_API_KEY", None)
+    monkeypatch.setattr(config, "EMAIL_ENABLED", True)
+
+    user = User(
+        id=uuid4(),
+        name="Injected User",
+        email="injected@test.com",
+        role=UserRole.instructor.value,
+        password_hash="x",
+        is_verified=True,
+        settings={"preferences": {"interface_mode": "expert"}},
+    )
+
+    state = build_initial_state(user)
+    assert state["auth"]["isAuthenticated"] is True
+    assert state["auth"]["user"]["email"] == "injected@test.com"
+    assert state["auth"]["user"]["role"] == "instructor"
+    assert state["auth"]["user"]["isVerified"] is True
+    assert state["auth"]["user"]["settings"]["preferences"]["interfaceMode"] == "expert"
+    assert "create_workflow" in state["auth"]["user"]["capabilities"]
+    assert state["features"]["emailEnabled"] is True
+    assert state["features"]["enforceEmailVerification"] is True
+    assert state["platform"]["deploymentMode"] == "ENTERPRISE"
+    assert state["platform"]["baseUrl"] == "https://fair.example.com"


### PR DESCRIPTION
This PR injects a tiny state script with user and platform data into the frontend so in many cases we don't have to fetch and show loaders for stuff llike current user, whether they are admin or whether email is enabled

i haven't tested this right