### PR TITLE
fix: add friendly service config error

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -61,6 +61,7 @@
                   "en/platform/assignments",
                   "en/platform/workflows",
                   "en/platform/integrations",
+                  "en/platform/ai-service",
                   "en/platform/settings"
                 ]
               }
@@ -120,6 +121,7 @@
                 "pages": [
                   "es/platform/workflows",
                   "es/platform/integrations",
+                  "es/platform/ai-service",
                   "es/platform/settings"
                 ]
               }

--- a/docs/en/platform/ai-service.md
+++ b/docs/en/platform/ai-service.md
@@ -1,0 +1,29 @@
+---
+title: AI Service
+description: Configure the global LLM settings used by FAIR features.
+---
+
+FAIR uses a global AI service for features that create content with a language model, such as rubric generation. These features require an administrator to configure the model provider before users can run them.
+
+## Required configuration
+
+Set the API key in the environment where the FAIR backend runs:
+
+```bash
+FAIR_LLM_API_KEY="your-provider-api-key"
+```
+
+If this value is missing, FAIR will show users a friendly configuration message instead of exposing provider-specific connection details.
+
+## Optional configuration
+
+Use these environment variables when you need a custom provider endpoint or model:
+
+| Variable | Default | Description |
+|---|---|---|
+| `FAIR_LLM_BASE_URL` | `https://api.openai.com/v1` | Base URL for the OpenAI-compatible chat completions API. |
+| `FAIR_LLM_MODEL` | `gpt-4o` | Model name used for backend AI features. |
+
+## After changing settings
+
+Restart the FAIR backend after updating these values so the service reads the new environment. Then try a feature such as rubric generation from a professor account to confirm the configuration works.

--- a/docs/es/platform/ai-service.md
+++ b/docs/es/platform/ai-service.md
@@ -1,0 +1,29 @@
+---
+title: Servicio de IA
+description: Configura los ajustes globales de LLM usados por FAIR.
+---
+
+FAIR usa un servicio global de IA para funciones que crean contenido con un modelo de lenguaje, como la generación de rúbricas. Estas funciones requieren que una persona administradora configure el proveedor del modelo antes de que los usuarios puedan ejecutarlas.
+
+## Configuración requerida
+
+Define la clave de API en el entorno donde se ejecuta el backend de FAIR:
+
+```bash
+FAIR_LLM_API_KEY="tu-clave-de-api-del-proveedor"
+```
+
+Si este valor no existe, FAIR mostrará a los usuarios un mensaje de configuración amigable en lugar de exponer detalles específicos del proveedor.
+
+## Configuración opcional
+
+Usa estas variables de entorno cuando necesites un endpoint de proveedor o modelo personalizado:
+
+| Variable | Predeterminado | Descripción |
+|---|---|---|
+| `FAIR_LLM_BASE_URL` | `https://api.openai.com/v1` | URL base para una API de chat completions compatible con OpenAI. |
+| `FAIR_LLM_MODEL` | `gpt-4o` | Nombre del modelo usado por las funciones de IA del backend. |
+
+## Después de cambiar la configuración
+
+Reinicia el backend de FAIR después de actualizar estos valores para que el servicio lea el nuevo entorno. Luego prueba una función como la generación de rúbricas desde una cuenta de profesor para confirmar que la configuración funciona.

--- a/src/fair_platform/backend/services/ai_service.py
+++ b/src/fair_platform/backend/services/ai_service.py
@@ -11,10 +11,17 @@ FAIR_LLM_BASE_URL: str = os.getenv("FAIR_LLM_BASE_URL", "https://api.openai.com/
 FAIR_LLM_MODEL: str = os.getenv("FAIR_LLM_MODEL", "gpt-4o")
 
 _ai_client: Optional[AsyncOpenAI] = None
+MISSING_AI_CONFIG_MESSAGE = (
+    "AI features are not configured yet. Ask an administrator to set FAIR_LLM_API_KEY "
+    "and review the AI service setup documentation."
+)
 
 
 def get_ai_client() -> AsyncOpenAI:
     global _ai_client
+    if not FAIR_LLM_API_KEY:
+        raise RuntimeError(MISSING_AI_CONFIG_MESSAGE)
+
     if _ai_client is None:
         _ai_client = AsyncOpenAI(
             api_key=FAIR_LLM_API_KEY,
@@ -33,4 +40,5 @@ __all__ = [
     "FAIR_LLM_API_KEY",
     "FAIR_LLM_BASE_URL",
     "FAIR_LLM_MODEL",
+    "MISSING_AI_CONFIG_MESSAGE",
 ]

--- a/src/fair_platform/backend/services/rubric_service.py
+++ b/src/fair_platform/backend/services/rubric_service.py
@@ -190,10 +190,9 @@ class RubricService:
             f"Instruction:\n{instruction}"
         )
 
-        client = get_ai_client()
-        model = get_llm_model()
-
         try:
+            client = get_ai_client()
+            model = get_llm_model()
             response = await client.chat.completions.create(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -32,15 +32,16 @@ class TestAIService:
         mock_client_instance = MagicMock()
         mock_async_openai.return_value = mock_client_instance
 
-        with patch("openai.AsyncOpenAI", mock_async_openai):
-            import fair_platform.backend.services.ai_service as ai_service
-            importlib.reload(ai_service)
+        with patch.dict("os.environ", {"FAIR_LLM_API_KEY": "test-api-key"}, clear=False):
+            with patch("openai.AsyncOpenAI", mock_async_openai):
+                import fair_platform.backend.services.ai_service as ai_service
+                importlib.reload(ai_service)
 
-            client1 = ai_service.get_ai_client()
-            client2 = ai_service.get_ai_client()
+                client1 = ai_service.get_ai_client()
+                client2 = ai_service.get_ai_client()
 
-            assert client1 is client2
-            assert mock_async_openai.call_count == 1
+                assert client1 is client2
+                assert mock_async_openai.call_count == 1
 
     def test_get_llm_model_returns_configured_model(self):
         with patch.dict("os.environ", {"FAIR_LLM_MODEL": "gpt-4-turbo"}, clear=False):
@@ -58,3 +59,21 @@ class TestAIService:
             importlib.reload(ai_service)
 
             assert ai_service.FAIR_LLM_BASE_URL == "https://api.openai.com/v1"
+
+    def test_get_ai_client_requires_configured_api_key(self):
+        env_without_api_keys = {
+            k: v
+            for k, v in __import__("os").environ.items()
+            if k not in {"FAIR_LLM_API_KEY", "OPENAI_API_KEY"}
+        }
+        with patch.dict("os.environ", env_without_api_keys, clear=True):
+            import fair_platform.backend.services.ai_service as ai_service
+            importlib.reload(ai_service)
+
+            with pytest.raises(RuntimeError) as exc_info:
+                ai_service.get_ai_client()
+
+            message = str(exc_info.value)
+            assert "AI features are not configured yet" in message
+            assert "FAIR_LLM_API_KEY" in message
+            assert "api_key client option" not in message

--- a/tests/test_rubric_generation_service.py
+++ b/tests/test_rubric_generation_service.py
@@ -69,3 +69,23 @@ async def test_generate_rubric_from_instruction_rejects_invalid_json():
             await service.generate_rubric_from_instruction("Essay rubric")
 
     assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_generate_rubric_from_instruction_handles_missing_ai_config():
+    service = RubricService(db=None)
+
+    with patch(
+        "fair_platform.backend.services.rubric_service.get_ai_client",
+        side_effect=RuntimeError(
+            "AI features are not configured yet. Ask an administrator to set FAIR_LLM_API_KEY "
+            "and review the AI service setup documentation."
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await service.generate_rubric_from_instruction("Essay rubric")
+
+    assert exc_info.value.status_code == 502
+    assert "AI features are not configured yet" in exc_info.value.detail
+    assert "FAIR_LLM_API_KEY" in exc_info.value.detail
+    assert "api_key client option" not in exc_info.value.detail


### PR DESCRIPTION
Fixes #157.

This changes missing model-provider configuration handling so rubric generation reports a stable application error instead of surfacing provider setup text. It also adds setup documentation in English and Spanish and coverage for the direct client path and rubric generation path.

Validation:
- `uv run --extra test pytest tests/test_ai_service.py tests/test_rubric_generation_service.py -q` (8 passed)
- `uv run ruff check src/fair_platform/backend/services/ai_service.py src/fair_platform/backend/services/rubric_service.py tests/test_ai_service.py tests/test_rubric_generation_service.py` (passed)
- `git diff --check` (passed)
