### PR TITLE
fix(ui): contain responsive table overflow

### DIFF
--- a/frontend-dev/src/components/ui/sidebar.tsx
+++ b/frontend-dev/src/components/ui/sidebar.tsx
@@ -508,7 +508,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background relative flex w-full flex-1 flex-col",
+        "bg-background relative flex min-w-0 w-full flex-1 flex-col",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className,
       )}


### PR DESCRIPTION
Fixes #123.

Allow the sidebar inset flex item to shrink below its content's intrinsic width. Wide tables now keep horizontal overflow inside the existing table scroller instead of widening the document and clipping the main app at narrow widths or browser zoom.

Validation:
- `bun run build`
- Browser regression check on a populated assignments table:
  - 600px viewport: document width 600px, table scrolls internally
  - 800px viewport: document width 800px, table scrolls internally
  - 1280px viewport: document width 1280px, table fits normally