### PR TITLE
fix(rubrics): retry invalid AI generations

### DIFF
--- a/src/fair_platform/backend/services/rubric_service.py
+++ b/src/fair_platform/backend/services/rubric_service.py
@@ -13,6 +13,7 @@ from fair_platform.backend.services.ai_service import get_ai_client, get_llm_mod
 
 
 WEIGHT_TOLERANCE = 1e-9
+RUBRIC_GENERATION_MAX_ATTEMPTS = 3
 
 
 def validate_rubric_content(content: dict) -> None:
@@ -114,7 +115,6 @@ def validate_rubric_content(content: dict) -> None:
 
 
 class RubricService:
-
     def __init__(self, db: Session):
         self.db = db
 
@@ -193,28 +193,43 @@ class RubricService:
         client = get_ai_client()
         model = get_llm_model()
 
-        try:
-            response = await client.chat.completions.create(
-                model=model,
-                messages=[{"role": "user", "content": prompt}],
-                temperature=1,
-            )
-        except Exception as e:
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=f"Failed to generate rubric content: {str(e)}",
-            ) from e
+        last_validation_error: HTTPException | None = None
 
-        content = response.choices[0].message.content if response.choices else None
-        if not content:
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail="Model returned empty rubric content",
-            )
+        for _attempt in range(RUBRIC_GENERATION_MAX_ATTEMPTS):
+            try:
+                response = await client.chat.completions.create(
+                    model=model,
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=1,
+                )
+            except Exception as e:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=f"Failed to generate rubric content: {str(e)}",
+                ) from e
 
-        parsed = _extract_rubric_json(content)
-        validate_rubric_content(parsed)
-        return parsed
+            content = response.choices[0].message.content if response.choices else None
+            if not content:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail="Model returned empty rubric content",
+                )
+
+            try:
+                parsed = _extract_rubric_json(content)
+                validate_rubric_content(parsed)
+            except HTTPException as e:
+                if e.status_code != status.HTTP_400_BAD_REQUEST:
+                    raise
+                last_validation_error = e
+                continue
+
+            return parsed
+
+        if last_validation_error is not None:
+            raise last_validation_error
+
+        raise RuntimeError("Rubric generation completed without a result")
 
 
 def _extract_rubric_json(content: str) -> dict:
@@ -235,7 +250,7 @@ def _extract_rubric_json(content: str) -> dict:
             )
 
         try:
-            parsed = json.loads(cleaned[first_brace:last_brace + 1])
+            parsed = json.loads(cleaned[first_brace : last_brace + 1])
         except json.JSONDecodeError as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/tests/test_rubric_generation_service.py
+++ b/tests/test_rubric_generation_service.py
@@ -36,12 +36,15 @@ async def test_generate_rubric_from_instruction_accepts_json_code_block():
 
     service = RubricService(db=None)
 
-    with patch(
-        "fair_platform.backend.services.rubric_service.get_ai_client",
-        return_value=fake_client,
-    ), patch(
-        "fair_platform.backend.services.rubric_service.get_llm_model",
-        return_value="test-model",
+    with (
+        patch(
+            "fair_platform.backend.services.rubric_service.get_ai_client",
+            return_value=fake_client,
+        ),
+        patch(
+            "fair_platform.backend.services.rubric_service.get_llm_model",
+            return_value="test-model",
+        ),
     ):
         generated = await service.generate_rubric_from_instruction("Essay rubric")
 
@@ -58,14 +61,97 @@ async def test_generate_rubric_from_instruction_rejects_invalid_json():
 
     service = RubricService(db=None)
 
-    with patch(
-        "fair_platform.backend.services.rubric_service.get_ai_client",
-        return_value=fake_client,
-    ), patch(
-        "fair_platform.backend.services.rubric_service.get_llm_model",
-        return_value="test-model",
+    with (
+        patch(
+            "fair_platform.backend.services.rubric_service.get_ai_client",
+            return_value=fake_client,
+        ),
+        patch(
+            "fair_platform.backend.services.rubric_service.get_llm_model",
+            return_value="test-model",
+        ),
     ):
         with pytest.raises(HTTPException) as exc_info:
             await service.generate_rubric_from_instruction("Essay rubric")
 
     assert exc_info.value.status_code == 400
+    assert fake_client.chat.completions.create.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_generate_rubric_from_instruction_retries_invalid_json():
+    valid_output = """{
+      "levels": ["Poor", "Fair", "Good", "Excellent"],
+      "criteria": [
+        {"name": "Content", "weight": 0.5, "levels": ["Missing", "Basic", "Solid", "Strong"]},
+        {"name": "Style", "weight": 0.5, "levels": ["Weak", "Developing", "Clear", "Excellent"]}
+      ]
+    }"""
+
+    fake_client = Mock()
+    fake_client.chat.completions.create = AsyncMock(
+        side_effect=[
+            _mock_completion_content("not-json"),
+            _mock_completion_content(valid_output),
+        ]
+    )
+
+    service = RubricService(db=None)
+
+    with (
+        patch(
+            "fair_platform.backend.services.rubric_service.get_ai_client",
+            return_value=fake_client,
+        ),
+        patch(
+            "fair_platform.backend.services.rubric_service.get_llm_model",
+            return_value="test-model",
+        ),
+    ):
+        generated = await service.generate_rubric_from_instruction("Essay rubric")
+
+    assert generated["levels"] == ["Poor", "Fair", "Good", "Excellent"]
+    assert fake_client.chat.completions.create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_rubric_from_instruction_retries_schema_validation_failure():
+    invalid_weights = """{
+      "levels": ["Poor", "Good"],
+      "criteria": [
+        {"name": "Content", "weight": 0.4, "levels": ["Missing", "Strong"]},
+        {"name": "Style", "weight": 0.4, "levels": ["Weak", "Clear"]}
+      ]
+    }"""
+    valid_output = """{
+      "levels": ["Poor", "Good"],
+      "criteria": [
+        {"name": "Content", "weight": 0.5, "levels": ["Missing", "Strong"]},
+        {"name": "Style", "weight": 0.5, "levels": ["Weak", "Clear"]}
+      ]
+    }"""
+
+    fake_client = Mock()
+    fake_client.chat.completions.create = AsyncMock(
+        side_effect=[
+            _mock_completion_content(invalid_weights),
+            _mock_completion_content(valid_output),
+        ]
+    )
+
+    service = RubricService(db=None)
+
+    with (
+        patch(
+            "fair_platform.backend.services.rubric_service.get_ai_client",
+            return_value=fake_client,
+        ),
+        patch(
+            "fair_platform.backend.services.rubric_service.get_llm_model",
+            return_value="test-model",
+        ),
+    ):
+        generated = await service.generate_rubric_from_instruction("Essay rubric")
+
+    assert sum(item["weight"] for item in generated["criteria"]) == 1.0
+    assert fake_client.chat.completions.create.await_count == 2


### PR DESCRIPTION
Fixes #138.

Retry AI rubric generation up to three times when a model response cannot be parsed as rubric JSON or fails rubric schema validation. Provider failures and empty upstream responses remain immediate 502 errors instead of being mistaken for correctable model output.

Coverage includes:
- retry after malformed JSON
- retry after schema-invalid weights
- success after a corrected response
- final 400 after all three invalid responses

Validation:
- `FAIR_ENFORCE_EMAIL_VERIFICATION=false uv run --extra test pytest tests/test_rubric_generation_service.py tests/test_rubric_api.py tests/test_rubric_validation.py -q` (43 passed)
- `uv run ruff check src/fair_platform/backend/services/rubric_service.py tests/test_rubric_generation_service.py`
- `uv run ruff format --check src/fair_platform/backend/services/rubric_service.py tests/test_rubric_generation_service.py`
- `git diff --check`