### PR TITLE
FAIR 1.0: canonical Flow and Extension API foundation

### DIFF
--- a/specs/fixtures/extension-manifest.json
+++ b/specs/fixtures/extension-manifest.json
@@ -1,0 +1,40 @@
+{
+  "manifestVersion": "1",
+  "extensionId": "fair.example.reviewer",
+  "displayName": "Example Reviewer",
+  "version": "1.0.0",
+  "dispatchUrl": "https://extensions.example.test/executions",
+  "healthUrl": "https://extensions.example.test/health",
+  "capabilities": [
+    {
+      "capabilityId": "review.assignment",
+      "kind": "agent",
+      "version": "1.0.0",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "urn:fair:example:review-input",
+        "type": "object",
+        "properties": {"submissionId": {"type": "string", "format": "uuid"}},
+        "required": ["submissionId"],
+        "additionalProperties": false
+      },
+      "configSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {"tone": {"type": "string", "enum": ["concise", "detailed"]}},
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {"feedback": {"type": "string"}},
+        "required": ["feedback"],
+        "additionalProperties": false
+      },
+      "requestedScopes": ["artifacts:read"],
+      "declaredEffects": ["feedback:write"],
+      "supportsStreaming": true,
+      "supportsCancellation": true
+    }
+  ]
+}

--- a/src/fair_platform/backend/api/routers/extensions.py
+++ b/src/fair_platform/backend/api/routers/extensions.py
@@ -1,306 +1,287 @@
-from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy.orm import Session
+from __future__ import annotations
+
 from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, selectinload
 
 from fair_platform.backend.api.routers.auth import get_current_user
 from fair_platform.backend.api.schema.extension import (
-    ExtensionClientIssueRequest,
-    ExtensionClientRead,
-    ExtensionClientSecretRead,
-    ExtensionClientUpdateRequest,
-    ExtensionRead,
-    ExtensionRegisterRequest,
+    CapabilityRead,
+    GrantCreate,
+    GrantRead,
+    InstallationCreate,
+    InstallationRead,
+    InstallationStatusUpdate,
 )
 from fair_platform.backend.core.security.permissions import has_capability
-from fair_platform.backend.core.security.dependencies import require_extension_client
 from fair_platform.backend.data.database import session_dependency
-from fair_platform.backend.data.models import ExtensionClient
-from fair_platform.backend.data.models.user import User
-from fair_platform.backend.services.extension_auth import issue_extension_secret
-from fair_platform.backend.services.extension_registry import (
-    ExtensionRegistration,
-    LocalExtensionRegistry,
+from fair_platform.backend.data.models import (
+    CapabilityDefinition,
+    ExtensionGrant,
+    ExtensionInstallation,
+    ExtensionInstallationStatus,
+    GrantDecision,
+    User,
 )
-from fair_platform.backend.services.settings_validator import (
-    SettingsSchemaValidationError,
-    validate_settings_schema,
-)
+from fair_platform.extension_sdk.contracts.extension import CapabilityManifest, ExtensionManifest
+
 
 router = APIRouter()
 
 
-def get_extension_registry(request: Request) -> LocalExtensionRegistry:
-    registry = getattr(request.app.state, "extension_registry", None)
-    if registry is None:
-        registry = LocalExtensionRegistry()
-        request.app.state.extension_registry = registry
-    return registry
+def _value(value: object) -> str:
+    return value.value if hasattr(value, "value") else str(value)
 
 
-@router.post("/", status_code=status.HTTP_201_CREATED, response_model=ExtensionRead)
-@router.post("/connect", status_code=status.HTTP_201_CREATED, response_model=ExtensionRead)
-async def register_extension(
-    payload: ExtensionRegisterRequest,
-    extension_client: ExtensionClient = Depends(require_extension_client(("extensions:connect",))),
-    registry: LocalExtensionRegistry = Depends(get_extension_registry),
-):
-    if extension_client.extension_id != payload.extension_id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Extension id does not match authenticated extension",
-        )
-    requested_scopes = sorted(
-        {
-            scope.strip()
-            for scope in (payload.requested_scopes or payload.capabilities)
-            if scope.strip()
-        }
-    )
-    approved_scopes = sorted(set(extension_client.scopes or []))
-    effective_scopes = [scope for scope in requested_scopes if scope in approved_scopes]
-    metadata = dict(payload.metadata)
-    raw_plugins = metadata.get("plugins")
-    if raw_plugins is not None:
-        if not isinstance(raw_plugins, list):
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=[
-                    {
-                        "type": "invalid_settings_schema",
-                        "plugin_id": payload.extension_id,
-                        "message": "metadata.plugins must be a list",
-                        "field_path": "plugins",
-                    }
-                ],
-            )
-        normalized_plugins: list[dict] = []
-        for index, raw_plugin in enumerate(raw_plugins):
-            if not isinstance(raw_plugin, dict):
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail=[
-                        {
-                            "type": "invalid_settings_schema",
-                            "plugin_id": payload.extension_id,
-                            "message": "plugin metadata entry must be an object",
-                            "field_path": f"plugins[{index}]",
-                        }
-                    ],
-                )
-            plugin_id = (
-                raw_plugin.get("pluginId")
-                or raw_plugin.get("plugin_id")
-                or f"plugins[{index}]"
-            )
-            raw_settings_schema = (
-                raw_plugin.get("settingsSchema")
-                if "settingsSchema" in raw_plugin
-                else raw_plugin.get("settings_schema")
-            )
-            try:
-                normalized_schema = validate_settings_schema(
-                    plugin_id=plugin_id,
-                    settings_schema=raw_settings_schema if raw_settings_schema is not None else {},
-                )
-            except SettingsSchemaValidationError as exc:
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail=exc.issues,
-                ) from exc
-            normalized_plugin = dict(raw_plugin)
-            normalized_plugin["settingsSchema"] = normalized_schema
-            normalized_plugins.append(normalized_plugin)
-        metadata["plugins"] = normalized_plugins
+def _require_admin(user: User) -> None:
+    if not has_capability(user, "admin"):
+        raise HTTPException(status_code=403, detail="Admin access required")
 
-    metadata["approved_scopes"] = approved_scopes
-    metadata["effective_scopes"] = effective_scopes
 
-    registration = await registry.register(
-        ExtensionRegistration(
-            extension_id=payload.extension_id,
-            webhook_url=payload.webhook_url,
-            intents=payload.intents,
-            capabilities=payload.capabilities,
-            metadata=metadata,
-        )
-    )
-    return ExtensionRead(
-        extension_id=registration.extension_id,
-        webhook_url=registration.webhook_url,
-        intents=registration.intents,
-        capabilities=registration.capabilities,
-        requested_scopes=requested_scopes,
-        metadata=registration.metadata,
-        enabled=registration.enabled,
+def _schema_uri(schema: dict, fallback: str) -> str:
+    return str(schema.get("$id") or fallback)
+
+
+def _capability_read(row: CapabilityDefinition) -> CapabilityRead:
+    snapshot = CapabilityManifest.model_validate(row.manifest_snapshot or {})
+    return CapabilityRead(
+        **snapshot.model_dump(),
+        id=row.id,
+        installation_id=row.installation_id,
+        created_at=row.created_at,
     )
 
 
-@router.get("/", response_model=list[ExtensionRead])
-async def list_extensions(
-    registry: LocalExtensionRegistry = Depends(get_extension_registry),
-):
-    records = await registry.list()
-    return [
-        ExtensionRead(
-            extension_id=record.extension_id,
-            webhook_url=record.webhook_url,
-            intents=record.intents,
-            capabilities=record.capabilities,
-            requested_scopes=list(record.metadata.get("effective_scopes", []))
-            if isinstance(record.metadata, dict)
-            else [],
-            metadata=record.metadata,
-            enabled=record.enabled,
-        )
-        for record in records
-    ]
-
-
-@router.get("/admin/clients", response_model=list[ExtensionClientRead])
-def list_extension_clients(
-    db: Session = Depends(session_dependency),
-    current_user: User = Depends(get_current_user),
-):
-    if not has_capability(current_user, "admin"):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only admin users can manage extension clients",
-        )
-    rows = db.query(ExtensionClient).order_by(ExtensionClient.extension_id.asc()).all()
-    return [
-        ExtensionClientRead(
-            extension_id=row.extension_id,
-            scopes=list(row.scopes or []),
-            enabled=bool(row.enabled),
-            created_at=row.created_at,
-            updated_at=row.updated_at,
-        )
-        for row in rows
-    ]
-
-
-@router.get("/admin/clients/{extension_id}", response_model=ExtensionClientRead)
-def get_extension_client(
-    extension_id: str,
-    db: Session = Depends(session_dependency),
-    current_user: User = Depends(get_current_user),
-):
-    if not has_capability(current_user, "admin"):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only admin users can manage extension clients",
-        )
-    row = db.get(ExtensionClient, extension_id)
-    if row is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Extension client not found",
-        )
-    return ExtensionClientRead(
+def _installation_read(row: ExtensionInstallation) -> InstallationRead:
+    manifest = ExtensionManifest.model_validate(row.manifest) if row.manifest else None
+    return InstallationRead(
+        id=row.id,
         extension_id=row.extension_id,
-        scopes=list(row.scopes or []),
-        enabled=bool(row.enabled),
+        display_name=row.display_name,
+        version=row.version,
+        dispatch_url=row.dispatch_url,
+        health_url=row.health_url,
+        manifest_version=row.manifest_version,
+        status=_value(row.status),
+        manifest=manifest,
+        capabilities=[_capability_read(item) for item in row.capabilities],
         created_at=row.created_at,
         updated_at=row.updated_at,
     )
 
 
-@router.patch("/admin/clients/{extension_id}", response_model=ExtensionClientRead)
-def update_extension_client(
-    extension_id: str,
-    payload: ExtensionClientUpdateRequest,
-    db: Session = Depends(session_dependency),
-    current_user: User = Depends(get_current_user),
-):
-    if not has_capability(current_user, "admin"):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only admin users can manage extension clients",
-        )
-    row = db.get(ExtensionClient, extension_id)
-    if row is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Extension client not found",
-        )
+def _grant_read(row: ExtensionGrant) -> GrantRead:
+    return GrantRead(
+        id=row.id,
+        installation_id=row.installation_id,
+        capability_definition_id=row.capability_definition_id,
+        course_id=row.course_id,
+        assignment_id=row.assignment_id,
+        effect=row.effect,
+        decision=_value(row.decision),
+        reason=row.reason,
+        granted_by_user_id=row.granted_by_user_id,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
 
-    normalized_scopes = sorted({scope.strip() for scope in payload.scopes if scope.strip()})
-    row.scopes = normalized_scopes
-    row.enabled = payload.enabled
-    row.updated_at = datetime.now(timezone.utc)
+
+@router.post("/installations", response_model=InstallationRead, status_code=status.HTTP_201_CREATED)
+def create_installation(
+    payload: InstallationCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> InstallationRead:
+    _require_admin(current_user)
+    manifest = payload.manifest
+    row = ExtensionInstallation(
+        extension_id=manifest.extension_id,
+        display_name=manifest.display_name,
+        version=manifest.version,
+        dispatch_url=str(manifest.dispatch_url),
+        health_url=str(manifest.health_url) if manifest.health_url else None,
+        manifest_version=manifest.manifest_version,
+        manifest=manifest.model_dump(by_alias=True, mode="json"),
+        status=ExtensionInstallationStatus.enabled,
+    )
     db.add(row)
+    db.flush()
+    for capability in manifest.capabilities:
+        raw = capability.model_dump(by_alias=True, mode="json")
+        base = f"urn:fair:extension:{manifest.extension_id}:capability:{capability.capability_id}:{capability.version}"
+        db.add(CapabilityDefinition(
+            installation_id=row.id,
+            capability_id=capability.capability_id,
+            kind=capability.kind,
+            version=capability.version,
+            input_schema_uri=_schema_uri(raw["inputSchema"], f"{base}:input"),
+            output_schema_uri=_schema_uri(raw["outputSchema"], f"{base}:output"),
+            config_schema_uri=(
+                _schema_uri(raw["configSchema"], f"{base}:config")
+                if raw.get("configSchema") else None
+            ),
+            requested_scopes=capability.requested_scopes,
+            declared_effects=capability.declared_effects,
+            supports_streaming=capability.supports_streaming,
+            supports_cancellation=capability.supports_cancellation,
+            supports_resume=capability.supports_resume,
+            supports_batch=capability.supports_batch,
+            manifest_snapshot=raw,
+        ))
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Extension installation already exists") from exc
+    return _installation_read(db.scalar(
+        select(ExtensionInstallation)
+        .options(selectinload(ExtensionInstallation.capabilities))
+        .where(ExtensionInstallation.id == row.id)
+    ))
+
+
+@router.get("/installations", response_model=list[InstallationRead])
+def list_installations(
+    include_disabled: bool = Query(False),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> list[InstallationRead]:
+    statement = select(ExtensionInstallation).options(
+        selectinload(ExtensionInstallation.capabilities)
+    ).order_by(ExtensionInstallation.extension_id)
+    if include_disabled:
+        _require_admin(current_user)
+    else:
+        statement = statement.where(
+            ExtensionInstallation.status == ExtensionInstallationStatus.enabled
+        )
+    return [_installation_read(row) for row in db.scalars(statement).unique()]
+
+
+@router.get("/installations/{installation_id}", response_model=InstallationRead)
+def get_installation(
+    installation_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> InstallationRead:
+    row = db.scalar(select(ExtensionInstallation).options(
+        selectinload(ExtensionInstallation.capabilities)
+    ).where(ExtensionInstallation.id == installation_id))
+    if row is None:
+        raise HTTPException(status_code=404, detail="Extension installation not found")
+    if _value(row.status) != "enabled":
+        _require_admin(current_user)
+    return _installation_read(row)
+
+
+@router.patch("/installations/{installation_id}", response_model=InstallationRead)
+def update_installation_status(
+    installation_id: UUID,
+    payload: InstallationStatusUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> InstallationRead:
+    _require_admin(current_user)
+    row = db.get(ExtensionInstallation, installation_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Extension installation not found")
+    row.status = ExtensionInstallationStatus(payload.status)
+    row.revoked_at = datetime.now(timezone.utc) if payload.status == "revoked" else None
     db.commit()
     db.refresh(row)
-    return ExtensionClientRead(
-        extension_id=row.extension_id,
-        scopes=list(row.scopes or []),
-        enabled=bool(row.enabled),
-        created_at=row.created_at,
-        updated_at=row.updated_at,
-    )
+    return _installation_read(row)
 
 
-@router.post(
-    "/admin/clients",
-    status_code=status.HTTP_201_CREATED,
-    response_model=ExtensionClientSecretRead,
-)
-def issue_extension_client_secret(
-    payload: ExtensionClientIssueRequest,
-    db: Session = Depends(session_dependency),
+@router.get("/capabilities", response_model=list[CapabilityRead])
+def list_capabilities(
+    installation_id: UUID | None = None,
     current_user: User = Depends(get_current_user),
-):
-    if not has_capability(current_user, "admin"):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only admin users can manage extension clients",
-        )
-    issued = issue_extension_secret(
-        db,
-        extension_id=payload.extension_id,
-        scopes=payload.scopes,
-        enabled=payload.enabled,
-    )
-    return ExtensionClientSecretRead(
-        extension_id=issued.extension_id,
-        extension_secret=issued.secret,
-        scopes=issued.scopes,
-        enabled=issued.enabled,
-    )
-
-
-@router.post(
-    "/admin/clients/{extension_id}/rotate",
-    response_model=ExtensionClientSecretRead,
-)
-def rotate_extension_client_secret(
-    extension_id: str,
     db: Session = Depends(session_dependency),
+) -> list[CapabilityRead]:
+    statement = select(CapabilityDefinition).join(ExtensionInstallation).where(
+        ExtensionInstallation.status == ExtensionInstallationStatus.enabled
+    ).order_by(CapabilityDefinition.capability_id, CapabilityDefinition.version)
+    if installation_id:
+        statement = statement.where(CapabilityDefinition.installation_id == installation_id)
+    return [_capability_read(row) for row in db.scalars(statement)]
+
+
+@router.get("/capabilities/{capability_id}", response_model=CapabilityRead)
+def get_capability(
+    capability_id: UUID,
     current_user: User = Depends(get_current_user),
-):
-    if not has_capability(current_user, "admin"):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only admin users can manage extension clients",
-        )
-    existing = db.get(ExtensionClient, extension_id)
-    if existing is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Extension client not found",
-        )
-    issued = issue_extension_secret(
-        db,
-        extension_id=extension_id,
-        scopes=list(existing.scopes or []),
-        enabled=bool(existing.enabled),
-    )
-    return ExtensionClientSecretRead(
-        extension_id=issued.extension_id,
-        extension_secret=issued.secret,
-        scopes=issued.scopes,
-        enabled=issued.enabled,
-    )
+    db: Session = Depends(session_dependency),
+) -> CapabilityRead:
+    row = db.scalar(select(CapabilityDefinition).join(ExtensionInstallation).where(
+        CapabilityDefinition.id == capability_id,
+        ExtensionInstallation.status == ExtensionInstallationStatus.enabled,
+    ))
+    if row is None:
+        raise HTTPException(status_code=404, detail="Capability not found")
+    return _capability_read(row)
 
 
-__all__ = ["router", "get_extension_registry"]
+@router.post("/grants", response_model=GrantRead, status_code=status.HTTP_201_CREATED)
+def create_grant(
+    payload: GrantCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> GrantRead:
+    _require_admin(current_user)
+    installation = db.get(ExtensionInstallation, payload.installation_id)
+    if installation is None:
+        raise HTTPException(status_code=404, detail="Extension installation not found")
+    if payload.capability_definition_id:
+        capability = db.get(CapabilityDefinition, payload.capability_definition_id)
+        if capability is None or capability.installation_id != installation.id:
+            raise HTTPException(status_code=422, detail="Capability does not belong to installation")
+        if payload.effect not in (capability.declared_effects or []):
+            raise HTTPException(status_code=422, detail="Effect is not declared by capability")
+    values = payload.model_dump()
+    values["decision"] = GrantDecision(payload.decision)
+    row = ExtensionGrant(
+        **values,
+        granted_by_user_id=current_user.id,
+    )
+    db.add(row)
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Grant already exists for this scope") from exc
+    db.refresh(row)
+    return _grant_read(row)
+
+
+@router.get("/grants", response_model=list[GrantRead])
+def list_grants(
+    installation_id: UUID | None = None,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> list[GrantRead]:
+    _require_admin(current_user)
+    statement = select(ExtensionGrant).order_by(ExtensionGrant.created_at, ExtensionGrant.id)
+    if installation_id:
+        statement = statement.where(ExtensionGrant.installation_id == installation_id)
+    return [_grant_read(row) for row in db.scalars(statement)]
+
+
+@router.delete("/grants/{grant_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_grant(
+    grant_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> None:
+    _require_admin(current_user)
+    row = db.get(ExtensionGrant, grant_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Grant not found")
+    db.delete(row)
+    db.commit()
+
+
+__all__ = ["router"]

--- a/src/fair_platform/backend/api/routers/flows.py
+++ b/src/fair_platform/backend/api/routers/flows.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from fair_platform.backend.api.routers.auth import get_current_user
+from fair_platform.backend.api.schema.flow import (
+    FlowCreate,
+    FlowExecutionRead,
+    FlowExecutionStart,
+    FlowRead,
+    FlowUpdate,
+    FlowVersionCreate,
+    FlowVersionRead,
+)
+from fair_platform.backend.data.database import session_dependency
+from fair_platform.backend.data.models import Flow, FlowVersion, User
+from fair_platform.backend.services.flow_service import (
+    FlowNotFound,
+    FlowStateError,
+    archive_flow_version,
+    create_flow,
+    create_flow_version,
+    get_owned_flow,
+    publish_flow_version,
+    start_flow_execution,
+)
+
+
+router = APIRouter(prefix="/flows")
+
+
+def _state(value: object) -> str:
+    return value.value if hasattr(value, "value") else str(value)
+
+
+def _version_read(version: FlowVersion) -> FlowVersionRead:
+    return FlowVersionRead(
+        id=version.id,
+        flow_id=version.flow_id,
+        ordinal=version.ordinal,
+        state=_state(version.state),
+        definition=version.definition,
+        capability_pins=version.capability_pins,
+        config_snapshot=version.config_snapshot,
+        definition_hash=version.definition_hash or "",
+        created_by_user_id=version.created_by_user_id,
+        created_at=version.created_at,
+        published_at=version.published_at,
+        archived_at=version.archived_at,
+    )
+
+
+def _flow_read(flow: Flow) -> FlowRead:
+    return FlowRead(
+        id=flow.id,
+        owner_user_id=flow.owner_user_id,
+        course_id=flow.course_id,
+        name=flow.name,
+        description=flow.description,
+        archived_at=flow.archived_at,
+        created_at=flow.created_at,
+        updated_at=flow.updated_at,
+        versions=[_version_read(version) for version in flow.versions],
+    )
+
+
+def _owned_flow(db: Session, flow_id: UUID, user: User) -> Flow:
+    try:
+        return get_owned_flow(db, flow_id, user.id)
+    except FlowNotFound as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+def _version(flow: Flow, version_id: UUID) -> FlowVersion:
+    for version in flow.versions:
+        if version.id == version_id:
+            return version
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND, detail="FlowVersion not found"
+    )
+
+
+@router.post("", response_model=FlowRead, status_code=status.HTTP_201_CREATED)
+def create_flow_route(
+    payload: FlowCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> FlowRead:
+    flow = create_flow(
+        db,
+        owner_user_id=current_user.id,
+        name=payload.name,
+        description=payload.description,
+        course_id=payload.course_id,
+    )
+    db.commit()
+    return _flow_read(flow)
+
+
+@router.get("", response_model=list[FlowRead])
+def list_flows(
+    include_archived: bool = False,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> list[FlowRead]:
+    query = select(Flow).where(Flow.owner_user_id == current_user.id)
+    if not include_archived:
+        query = query.where(Flow.archived_at.is_(None))
+    flows = db.scalars(query.order_by(Flow.updated_at.desc())).unique().all()
+    return [_flow_read(flow) for flow in flows]
+
+
+@router.get("/{flow_id}", response_model=FlowRead)
+def get_flow(
+    flow_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> FlowRead:
+    return _flow_read(_owned_flow(db, flow_id, current_user))
+
+
+@router.patch("/{flow_id}", response_model=FlowRead)
+def update_flow(
+    flow_id: UUID,
+    payload: FlowUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> FlowRead:
+    flow = _owned_flow(db, flow_id, current_user)
+    if flow.archived_at is not None:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Flow is archived")
+    if payload.name is not None:
+        flow.name = payload.name
+    if "description" in payload.model_fields_set:
+        flow.description = payload.description
+    db.commit()
+    return _flow_read(flow)
+
+
+@router.delete("/{flow_id}", response_model=FlowRead)
+def archive_flow(
+    flow_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> FlowRead:
+    flow = _owned_flow(db, flow_id, current_user)
+    if flow.archived_at is None:
+        flow.archived_at = datetime.now(timezone.utc)
+        db.commit()
+    return _flow_read(flow)
+
+
+@router.post(
+    "/{flow_id}/versions",
+    response_model=FlowVersionRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_version(
+    flow_id: UUID,
+    payload: FlowVersionCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> FlowVersionRead:
+    flow = _owned_flow(db, flow_id, current_user)
+    try:
+        version = create_flow_version(
+            db,
+            flow=flow,
+            created_by_user_id=current_user.id,
+            definition=payload.definition,
+            capability_pins=payload.capability_pins,
+            config_snapshot=payload.config_snapshot,
+        )
+        db.commit()
+    except FlowStateError as exc:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    return _version_read(version)
+
+
+@router.get("/{flow_id}/versions", response_model=list[FlowVersionRead])
+def list_versions(
+    flow_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> list[FlowVersionRead]:
+    flow = _owned_flow(db, flow_id, current_user)
+    return [_version_read(version) for version in flow.versions]
+
+
+@router.post("/{flow_id}/versions/{version_id}/publish", response_model=FlowVersionRead)
+def publish_version(
+    flow_id: UUID,
+    version_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> FlowVersionRead:
+    flow = _owned_flow(db, flow_id, current_user)
+    try:
+        version = publish_flow_version(db, _version(flow, version_id))
+        db.commit()
+    except FlowStateError as exc:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    return _version_read(version)
+
+
+@router.post("/{flow_id}/versions/{version_id}/archive", response_model=FlowVersionRead)
+def archive_version(
+    flow_id: UUID,
+    version_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> FlowVersionRead:
+    flow = _owned_flow(db, flow_id, current_user)
+    try:
+        version = archive_flow_version(db, _version(flow, version_id))
+        db.commit()
+    except FlowStateError as exc:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    return _version_read(version)
+
+
+@router.post(
+    "/{flow_id}/executions",
+    response_model=FlowExecutionRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def start_execution(
+    flow_id: UUID,
+    payload: FlowExecutionStart,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> FlowExecutionRead:
+    flow = _owned_flow(db, flow_id, current_user)
+    if flow.archived_at is not None:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Flow is archived")
+    try:
+        execution, version, dispatch = start_flow_execution(
+            db,
+            flow=flow,
+            initiated_by_user_id=current_user.id,
+            input_payload=payload.input,
+            flow_version_id=payload.flow_version_id,
+        )
+        db.commit()
+    except FlowStateError as exc:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    return FlowExecutionRead(
+        execution_id=execution.id,
+        flow_version_id=version.id,
+        status=_state(execution.status),
+        dispatch_id=dispatch.id,
+    )
+
+
+__all__ = ["router"]

--- a/src/fair_platform/backend/api/routers/legacy_extensions.py
+++ b/src/fair_platform/backend/api/routers/legacy_extensions.py
@@ -1,0 +1,306 @@
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+from datetime import datetime, timezone
+
+from fair_platform.backend.api.routers.auth import get_current_user
+from fair_platform.backend.api.schema.extension import (
+    ExtensionClientIssueRequest,
+    ExtensionClientRead,
+    ExtensionClientSecretRead,
+    ExtensionClientUpdateRequest,
+    ExtensionRead,
+    ExtensionRegisterRequest,
+)
+from fair_platform.backend.core.security.permissions import has_capability
+from fair_platform.backend.core.security.dependencies import require_extension_client
+from fair_platform.backend.data.database import session_dependency
+from fair_platform.backend.data.models import ExtensionClient
+from fair_platform.backend.data.models.user import User
+from fair_platform.backend.services.extension_auth import issue_extension_secret
+from fair_platform.backend.services.extension_registry import (
+    ExtensionRegistration,
+    LocalExtensionRegistry,
+)
+from fair_platform.backend.services.settings_validator import (
+    SettingsSchemaValidationError,
+    validate_settings_schema,
+)
+
+router = APIRouter()
+
+
+def get_extension_registry(request: Request) -> LocalExtensionRegistry:
+    registry = getattr(request.app.state, "extension_registry", None)
+    if registry is None:
+        registry = LocalExtensionRegistry()
+        request.app.state.extension_registry = registry
+    return registry
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED, response_model=ExtensionRead)
+@router.post("/connect", status_code=status.HTTP_201_CREATED, response_model=ExtensionRead)
+async def register_extension(
+    payload: ExtensionRegisterRequest,
+    extension_client: ExtensionClient = Depends(require_extension_client(("extensions:connect",))),
+    registry: LocalExtensionRegistry = Depends(get_extension_registry),
+):
+    if extension_client.extension_id != payload.extension_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Extension id does not match authenticated extension",
+        )
+    requested_scopes = sorted(
+        {
+            scope.strip()
+            for scope in (payload.requested_scopes or payload.capabilities)
+            if scope.strip()
+        }
+    )
+    approved_scopes = sorted(set(extension_client.scopes or []))
+    effective_scopes = [scope for scope in requested_scopes if scope in approved_scopes]
+    metadata = dict(payload.metadata)
+    raw_plugins = metadata.get("plugins")
+    if raw_plugins is not None:
+        if not isinstance(raw_plugins, list):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=[
+                    {
+                        "type": "invalid_settings_schema",
+                        "plugin_id": payload.extension_id,
+                        "message": "metadata.plugins must be a list",
+                        "field_path": "plugins",
+                    }
+                ],
+            )
+        normalized_plugins: list[dict] = []
+        for index, raw_plugin in enumerate(raw_plugins):
+            if not isinstance(raw_plugin, dict):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=[
+                        {
+                            "type": "invalid_settings_schema",
+                            "plugin_id": payload.extension_id,
+                            "message": "plugin metadata entry must be an object",
+                            "field_path": f"plugins[{index}]",
+                        }
+                    ],
+                )
+            plugin_id = (
+                raw_plugin.get("pluginId")
+                or raw_plugin.get("plugin_id")
+                or f"plugins[{index}]"
+            )
+            raw_settings_schema = (
+                raw_plugin.get("settingsSchema")
+                if "settingsSchema" in raw_plugin
+                else raw_plugin.get("settings_schema")
+            )
+            try:
+                normalized_schema = validate_settings_schema(
+                    plugin_id=plugin_id,
+                    settings_schema=raw_settings_schema if raw_settings_schema is not None else {},
+                )
+            except SettingsSchemaValidationError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=exc.issues,
+                ) from exc
+            normalized_plugin = dict(raw_plugin)
+            normalized_plugin["settingsSchema"] = normalized_schema
+            normalized_plugins.append(normalized_plugin)
+        metadata["plugins"] = normalized_plugins
+
+    metadata["approved_scopes"] = approved_scopes
+    metadata["effective_scopes"] = effective_scopes
+
+    registration = await registry.register(
+        ExtensionRegistration(
+            extension_id=payload.extension_id,
+            webhook_url=payload.webhook_url,
+            intents=payload.intents,
+            capabilities=payload.capabilities,
+            metadata=metadata,
+        )
+    )
+    return ExtensionRead(
+        extension_id=registration.extension_id,
+        webhook_url=registration.webhook_url,
+        intents=registration.intents,
+        capabilities=registration.capabilities,
+        requested_scopes=requested_scopes,
+        metadata=registration.metadata,
+        enabled=registration.enabled,
+    )
+
+
+@router.get("/", response_model=list[ExtensionRead])
+async def list_extensions(
+    registry: LocalExtensionRegistry = Depends(get_extension_registry),
+):
+    records = await registry.list()
+    return [
+        ExtensionRead(
+            extension_id=record.extension_id,
+            webhook_url=record.webhook_url,
+            intents=record.intents,
+            capabilities=record.capabilities,
+            requested_scopes=list(record.metadata.get("effective_scopes", []))
+            if isinstance(record.metadata, dict)
+            else [],
+            metadata=record.metadata,
+            enabled=record.enabled,
+        )
+        for record in records
+    ]
+
+
+@router.get("/admin/clients", response_model=list[ExtensionClientRead])
+def list_extension_clients(
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+):
+    if not has_capability(current_user, "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only admin users can manage extension clients",
+        )
+    rows = db.query(ExtensionClient).order_by(ExtensionClient.extension_id.asc()).all()
+    return [
+        ExtensionClientRead(
+            extension_id=row.extension_id,
+            scopes=list(row.scopes or []),
+            enabled=bool(row.enabled),
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
+        for row in rows
+    ]
+
+
+@router.get("/admin/clients/{extension_id}", response_model=ExtensionClientRead)
+def get_extension_client(
+    extension_id: str,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+):
+    if not has_capability(current_user, "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only admin users can manage extension clients",
+        )
+    row = db.get(ExtensionClient, extension_id)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Extension client not found",
+        )
+    return ExtensionClientRead(
+        extension_id=row.extension_id,
+        scopes=list(row.scopes or []),
+        enabled=bool(row.enabled),
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+@router.patch("/admin/clients/{extension_id}", response_model=ExtensionClientRead)
+def update_extension_client(
+    extension_id: str,
+    payload: ExtensionClientUpdateRequest,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+):
+    if not has_capability(current_user, "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only admin users can manage extension clients",
+        )
+    row = db.get(ExtensionClient, extension_id)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Extension client not found",
+        )
+
+    normalized_scopes = sorted({scope.strip() for scope in payload.scopes if scope.strip()})
+    row.scopes = normalized_scopes
+    row.enabled = payload.enabled
+    row.updated_at = datetime.now(timezone.utc)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return ExtensionClientRead(
+        extension_id=row.extension_id,
+        scopes=list(row.scopes or []),
+        enabled=bool(row.enabled),
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+@router.post(
+    "/admin/clients",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ExtensionClientSecretRead,
+)
+def issue_extension_client_secret(
+    payload: ExtensionClientIssueRequest,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+):
+    if not has_capability(current_user, "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only admin users can manage extension clients",
+        )
+    issued = issue_extension_secret(
+        db,
+        extension_id=payload.extension_id,
+        scopes=payload.scopes,
+        enabled=payload.enabled,
+    )
+    return ExtensionClientSecretRead(
+        extension_id=issued.extension_id,
+        extension_secret=issued.secret,
+        scopes=issued.scopes,
+        enabled=issued.enabled,
+    )
+
+
+@router.post(
+    "/admin/clients/{extension_id}/rotate",
+    response_model=ExtensionClientSecretRead,
+)
+def rotate_extension_client_secret(
+    extension_id: str,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+):
+    if not has_capability(current_user, "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only admin users can manage extension clients",
+        )
+    existing = db.get(ExtensionClient, extension_id)
+    if existing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Extension client not found",
+        )
+    issued = issue_extension_secret(
+        db,
+        extension_id=extension_id,
+        scopes=list(existing.scopes or []),
+        enabled=bool(existing.enabled),
+    )
+    return ExtensionClientSecretRead(
+        extension_id=issued.extension_id,
+        extension_secret=issued.secret,
+        scopes=issued.scopes,
+        enabled=issued.enabled,
+    )
+
+
+__all__ = ["router", "get_extension_registry"]

--- a/src/fair_platform/backend/api/schema/extension.py
+++ b/src/fair_platform/backend/api/schema/extension.py
@@ -1,17 +1,74 @@
+from __future__ import annotations
+
 from datetime import datetime
+from typing import Literal
+from uuid import UUID
 
 from pydantic import BaseModel, Field
 
 from fair_platform.backend.api.schema.utils import schema_config
 from fair_platform.extension_sdk.contracts.extension import (
-    ExtensionRead,
-    ExtensionRegisterRequest,
+    CapabilityManifest,
+    ExtensionManifest,
+    ExtensionRead,  # noqa: F401 - re-exported for the retiring registry router
+    ExtensionRegisterRequest,  # noqa: F401 - re-exported for the retiring registry router
+    JsonSchemaDocument,  # noqa: F401 - public backend schema surface
 )
 
 
+class InstallationCreate(BaseModel):
+    model_config = schema_config
+    manifest: ExtensionManifest
+
+
+class InstallationStatusUpdate(BaseModel):
+    model_config = schema_config
+    status: Literal["enabled", "disabled", "revoked"]
+
+
+class CapabilityRead(CapabilityManifest):
+    id: UUID
+    installation_id: UUID
+    created_at: datetime
+
+
+class InstallationRead(BaseModel):
+    model_config = schema_config
+    id: UUID
+    extension_id: str
+    display_name: str | None
+    version: str | None
+    dispatch_url: str | None
+    health_url: str | None
+    manifest_version: str | None
+    status: str
+    manifest: ExtensionManifest | None
+    capabilities: list[CapabilityRead] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+
+class GrantCreate(BaseModel):
+    model_config = schema_config
+    installation_id: UUID
+    capability_definition_id: UUID | None = None
+    course_id: UUID | None = None
+    assignment_id: UUID | None = None
+    effect: str = Field(min_length=1, max_length=128, pattern=r"^[a-z][a-z0-9._-]*:[a-z][a-z0-9._-]*$")
+    decision: Literal["allow", "deny"]
+    reason: str | None = Field(default=None, max_length=2000)
+
+
+class GrantRead(GrantCreate):
+    id: UUID
+    granted_by_user_id: UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+
+# Client credential administration stays available to the existing router.
 class ExtensionClientIssueRequest(BaseModel):
     model_config = schema_config
-
     extension_id: str = Field(min_length=1)
     scopes: list[str] = Field(default_factory=list)
     enabled: bool = True
@@ -19,7 +76,6 @@ class ExtensionClientIssueRequest(BaseModel):
 
 class ExtensionClientSecretRead(BaseModel):
     model_config = schema_config
-
     extension_id: str
     extension_secret: str
     scopes: list[str] = Field(default_factory=list)
@@ -28,7 +84,6 @@ class ExtensionClientSecretRead(BaseModel):
 
 class ExtensionClientRead(BaseModel):
     model_config = schema_config
-
     extension_id: str
     scopes: list[str] = Field(default_factory=list)
     enabled: bool
@@ -38,16 +93,8 @@ class ExtensionClientRead(BaseModel):
 
 class ExtensionClientUpdateRequest(BaseModel):
     model_config = schema_config
-
     scopes: list[str] = Field(default_factory=list)
     enabled: bool
 
 
-__all__ = [
-    "ExtensionRegisterRequest",
-    "ExtensionRead",
-    "ExtensionClientIssueRequest",
-    "ExtensionClientSecretRead",
-    "ExtensionClientRead",
-    "ExtensionClientUpdateRequest",
-]
+__all__ = [name for name in globals() if not name.startswith("_")]

--- a/src/fair_platform/backend/api/schema/flow.py
+++ b/src/fair_platform/backend/api/schema/flow.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from fair_platform.backend.api.schema.utils import schema_config
+
+
+class FlowCreate(BaseModel):
+    model_config = schema_config
+
+    name: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    course_id: UUID | None = None
+
+
+class FlowUpdate(BaseModel):
+    model_config = schema_config
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+
+
+class FlowVersionCreate(BaseModel):
+    model_config = schema_config
+
+    definition: dict[str, Any]
+    capability_pins: list[dict[str, Any]] = Field(default_factory=list)
+    config_snapshot: dict[str, Any] = Field(default_factory=dict)
+
+
+class FlowVersionRead(FlowVersionCreate):
+    id: UUID
+    flow_id: UUID
+    ordinal: int
+    state: str
+    definition_hash: str
+    created_by_user_id: UUID
+    created_at: datetime
+    published_at: datetime | None
+    archived_at: datetime | None
+
+
+class FlowRead(BaseModel):
+    model_config = schema_config
+
+    id: UUID
+    owner_user_id: UUID
+    course_id: UUID | None
+    name: str
+    description: str | None
+    archived_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+    versions: list[FlowVersionRead] = Field(default_factory=list)
+
+
+class FlowExecutionStart(BaseModel):
+    model_config = schema_config
+
+    flow_version_id: UUID | None = None
+    input: dict[str, Any] = Field(default_factory=dict)
+
+
+class FlowExecutionRead(BaseModel):
+    model_config = schema_config
+
+    execution_id: UUID
+    flow_version_id: UUID
+    status: str
+    dispatch_id: UUID
+
+
+__all__ = [
+    "FlowCreate",
+    "FlowExecutionRead",
+    "FlowExecutionStart",
+    "FlowRead",
+    "FlowUpdate",
+    "FlowVersionCreate",
+    "FlowVersionRead",
+]

--- a/src/fair_platform/backend/main.py
+++ b/src/fair_platform/backend/main.py
@@ -28,10 +28,12 @@ from fair_platform.backend.api.routers.version import router as version_router
 from fair_platform.backend.api.routers.rubrics import router as rubrics_router
 from fair_platform.backend.api.routers.enrollments import router as enrollments_router
 from fair_platform.backend.api.routers.jobs import router as jobs_router
-from fair_platform.backend.api.routers.extensions import router as extensions_router
+from fair_platform.backend.api.routers.legacy_extensions import router as extensions_router
+from fair_platform.backend.api.routers.extensions import router as extension_resources_router
 from fair_platform.backend.api.routers.system import router as system_router
 from fair_platform.backend.api.routers.executions import router as executions_router
 from fair_platform.backend.api.routers.artifacts import router as artifacts_router
+from fair_platform.backend.api.routers.flows import router as flows_router
 from fair_platform.backend.services.extension_registry import LocalExtensionRegistry
 from fair_platform.backend.services.job_dispatcher import JobDispatcher
 from fair_platform.backend.services.execution_outbox_dispatcher import (
@@ -254,6 +256,12 @@ app.include_router(extensions_router, prefix="/api/extensions", tags=["extension
 app.include_router(system_router, prefix="/api/v1/system", tags=["system"])
 app.include_router(executions_router, prefix="/api/v1", tags=["executions"])
 app.include_router(artifacts_router, prefix="/api/v1", tags=["artifacts"])
+app.include_router(flows_router, prefix="/api/v1", tags=["flows"])
+app.include_router(
+    extension_resources_router,
+    prefix="/api/v1/extensions",
+    tags=["extensions"],
+)
 
 
 @app.get("/health")

--- a/src/fair_platform/backend/services/flow_service.py
+++ b/src/fair_platform/backend/services/flow_service.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import func, select, update
+from sqlalchemy.orm import Session, selectinload
+
+from fair_platform.backend.data.models.execution import ExecutionKind
+from fair_platform.backend.data.models.flow import Flow, FlowVersion, FlowVersionState
+from fair_platform.backend.services.execution_outbox import enqueue_dispatch
+from fair_platform.backend.services.execution_store import create_execution
+
+
+class FlowNotFound(ValueError):
+    pass
+
+
+class FlowStateError(ValueError):
+    pass
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _state(value: object) -> str:
+    return value.value if hasattr(value, "value") else str(value)
+
+
+def _version_hash(
+    definition: dict, capability_pins: list[dict], config_snapshot: dict
+) -> str:
+    encoded = json.dumps(
+        {
+            "definition": definition,
+            "capabilityPins": capability_pins,
+            "configSnapshot": config_snapshot,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _flow_allocation_lock_statement(flow_id: UUID):
+    return select(Flow.id).where(Flow.id == flow_id).with_for_update()
+
+
+def get_owned_flow(session: Session, flow_id: UUID, owner_user_id: UUID) -> Flow:
+    flow = session.scalar(
+        select(Flow)
+        .where(Flow.id == flow_id, Flow.owner_user_id == owner_user_id)
+        .options(selectinload(Flow.versions))
+    )
+    if flow is None:
+        raise FlowNotFound(f"Flow {flow_id} does not exist")
+    return flow
+
+
+def create_flow(
+    session: Session,
+    *,
+    owner_user_id: UUID,
+    name: str,
+    description: str | None,
+    course_id: UUID | None,
+) -> Flow:
+    flow = Flow(
+        owner_user_id=owner_user_id,
+        name=name,
+        description=description,
+        course_id=course_id,
+    )
+    session.add(flow)
+    session.flush()
+    return flow
+
+
+def create_flow_version(
+    session: Session,
+    *,
+    flow: Flow,
+    created_by_user_id: UUID,
+    definition: dict,
+    capability_pins: list[dict],
+    config_snapshot: dict,
+) -> FlowVersion:
+    if flow.archived_at is not None:
+        raise FlowStateError("Archived Flows cannot receive new versions")
+    # Serialize ordinal allocation per Flow. PostgreSQL emits SELECT ... FOR
+    # UPDATE; SQLite safely ignores the unsupported locking clause.
+    if session.scalar(_flow_allocation_lock_statement(flow.id)) is None:
+        raise FlowNotFound(f"Flow {flow.id} does not exist")
+    next_ordinal = (
+        session.scalar(
+            select(func.max(FlowVersion.ordinal)).where(FlowVersion.flow_id == flow.id)
+        )
+        or 0
+    ) + 1
+    version = FlowVersion(
+        flow_id=flow.id,
+        ordinal=next_ordinal,
+        definition=definition,
+        capability_pins=capability_pins,
+        config_snapshot=config_snapshot,
+        definition_hash=_version_hash(
+            definition, capability_pins, config_snapshot
+        ),
+        created_by_user_id=created_by_user_id,
+    )
+    session.add(version)
+    session.flush()
+    return version
+
+
+def publish_flow_version(session: Session, version: FlowVersion) -> FlowVersion:
+    if _state(version.state) != FlowVersionState.draft.value:
+        raise FlowStateError("Only a draft FlowVersion can be published")
+    version.state = FlowVersionState.published
+    version.published_at = _now()
+    session.flush()
+    return version
+
+
+def archive_flow_version(session: Session, version: FlowVersion) -> FlowVersion:
+    if _state(version.state) != FlowVersionState.published.value:
+        raise FlowStateError("Only a published FlowVersion can be archived")
+    archived_at = _now()
+    # Published versions are otherwise immutable. A direct transition updates only
+    # the lifecycle columns and deliberately bypasses ordinary ORM mutation.
+    session.execute(
+        update(FlowVersion)
+        .where(FlowVersion.id == version.id)
+        .values(state=FlowVersionState.archived, archived_at=archived_at)
+    )
+    session.expire(version)
+    return version
+
+
+def start_flow_execution(
+    session: Session,
+    *,
+    flow: Flow,
+    initiated_by_user_id: UUID,
+    input_payload: dict,
+    flow_version_id: UUID | None,
+):
+    query = select(FlowVersion).where(
+        FlowVersion.flow_id == flow.id,
+        FlowVersion.state == FlowVersionState.published,
+    )
+    if flow_version_id is not None:
+        query = query.where(FlowVersion.id == flow_version_id)
+    else:
+        query = query.order_by(FlowVersion.ordinal.desc())
+    version = session.scalar(query)
+    if version is None:
+        raise FlowStateError("A published FlowVersion is required to start a Flow")
+
+    execution = create_execution(
+        session,
+        kind=ExecutionKind.flow.value,
+        initiated_by_user_id=initiated_by_user_id,
+        flow_version_id=version.id,
+        input=input_payload,
+    )
+    dispatch = enqueue_dispatch(
+        session,
+        execution_id=execution.id,
+        target="flow.executor",
+        payload={
+            "executionId": str(execution.id),
+            "flowId": str(flow.id),
+            "flowVersionId": str(version.id),
+            "definitionHash": version.definition_hash,
+            "input": input_payload,
+        },
+    )
+    return execution, version, dispatch
+
+
+__all__ = [
+    "FlowNotFound",
+    "FlowStateError",
+    "archive_flow_version",
+    "create_flow",
+    "create_flow_version",
+    "get_owned_flow",
+    "publish_flow_version",
+    "start_flow_execution",
+]

--- a/src/fair_platform/extension_sdk/contracts/extension.py
+++ b/src/fair_platform/extension_sdk/contracts/extension.py
@@ -1,13 +1,105 @@
-from typing import Any
+from __future__ import annotations
 
-from pydantic import BaseModel, Field
+import re
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, HttpUrl, field_validator, model_validator
 
 from fair_platform.extension_sdk.contracts.common import contract_model_config
 
 
-class ExtensionRegisterRequest(BaseModel):
+IDENTIFIER_PATTERN = re.compile(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$")
+
+
+class JsonSchemaDocument(BaseModel):
+    """A JSON Schema embedded in an extension manifest."""
+
     model_config = contract_model_config
 
+    schema_: str = Field(default="https://json-schema.org/draft/2020-12/schema", alias="$schema")
+    id_: str | None = Field(default=None, alias="$id")
+    type: str | list[str]
+    title: str | None = None
+    description: str | None = None
+    properties: dict[str, Any] = Field(default_factory=dict)
+    required: list[str] = Field(default_factory=list)
+    additional_properties: bool | dict[str, Any] | None = Field(
+        default=None, alias="additionalProperties"
+    )
+
+    @model_validator(mode="after")
+    def validate_object_keywords(self) -> "JsonSchemaDocument":
+        types = {self.type} if isinstance(self.type, str) else set(self.type)
+        if (self.properties or self.required) and "object" not in types:
+            raise ValueError("properties and required are only valid for object schemas")
+        unknown_required = set(self.required) - set(self.properties)
+        if unknown_required:
+            raise ValueError(f"required fields lack property definitions: {sorted(unknown_required)}")
+        return self
+
+
+class CapabilityManifest(BaseModel):
+    model_config = contract_model_config
+
+    capability_id: str = Field(min_length=1, max_length=255)
+    kind: Literal["agent", "grader", "transformer", "tool", "integration"]
+    version: str = Field(min_length=1, max_length=128)
+    input_schema: JsonSchemaDocument
+    output_schema: JsonSchemaDocument
+    config_schema: JsonSchemaDocument | None = None
+    requested_scopes: list[str] = Field(default_factory=list)
+    declared_effects: list[str] = Field(default_factory=list)
+    supports_streaming: bool = False
+    supports_cancellation: bool = False
+    supports_resume: bool = False
+    supports_batch: bool = False
+
+    @field_validator("capability_id")
+    @classmethod
+    def valid_capability_id(cls, value: str) -> str:
+        if not IDENTIFIER_PATTERN.fullmatch(value):
+            raise ValueError("capability_id must be a lowercase dotted identifier")
+        return value
+
+    @field_validator("requested_scopes", "declared_effects")
+    @classmethod
+    def normalized_unique_values(cls, values: list[str]) -> list[str]:
+        normalized = [value.strip() for value in values]
+        if any(not value for value in normalized) or len(set(normalized)) != len(normalized):
+            raise ValueError("values must be non-blank and unique")
+        return normalized
+
+
+class ExtensionManifest(BaseModel):
+    model_config = contract_model_config
+
+    manifest_version: Literal["1"] = "1"
+    extension_id: str = Field(min_length=1, max_length=255)
+    display_name: str = Field(min_length=1, max_length=255)
+    version: str = Field(min_length=1, max_length=128)
+    dispatch_url: HttpUrl
+    health_url: HttpUrl | None = None
+    capabilities: list[CapabilityManifest] = Field(min_length=1)
+
+    @field_validator("extension_id")
+    @classmethod
+    def valid_extension_id(cls, value: str) -> str:
+        if not IDENTIFIER_PATTERN.fullmatch(value):
+            raise ValueError("extension_id must be a lowercase dotted identifier")
+        return value
+
+    @model_validator(mode="after")
+    def unique_capabilities(self) -> "ExtensionManifest":
+        identities = [(item.capability_id, item.version) for item in self.capabilities]
+        if len(set(identities)) != len(identities):
+            raise ValueError("capability_id and version pairs must be unique")
+        return self
+
+
+# Transitional runtime registration shapes retained until the old in-memory
+# registry router is removed from application wiring.
+class ExtensionRegisterRequest(BaseModel):
+    model_config = contract_model_config
     extension_id: str = Field(min_length=1)
     webhook_url: str = Field(min_length=1)
     intents: list[str] = Field(default_factory=list)
@@ -18,7 +110,6 @@ class ExtensionRegisterRequest(BaseModel):
 
 class ExtensionRead(BaseModel):
     model_config = contract_model_config
-
     extension_id: str
     webhook_url: str
     intents: list[str]
@@ -28,4 +119,7 @@ class ExtensionRead(BaseModel):
     enabled: bool
 
 
-__all__ = ["ExtensionRegisterRequest", "ExtensionRead"]
+__all__ = [
+    "CapabilityManifest", "ExtensionManifest", "JsonSchemaDocument",
+    "ExtensionRead", "ExtensionRegisterRequest",
+]

--- a/tests/test_extension_contracts.py
+++ b/tests/test_extension_contracts.py
@@ -1,0 +1,103 @@
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from fair_platform.backend.api.routers.auth import get_current_user
+from fair_platform.backend.api.routers.extensions import router
+from fair_platform.backend.data.database import session_dependency
+from fair_platform.backend.data.models import User, UserRole
+from fair_platform.extension_sdk.contracts.extension import ExtensionManifest
+
+
+FIXTURE = Path("specs/fixtures/extension-manifest.json")
+
+
+def _client(test_db, user):
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1/extensions")
+    app.dependency_overrides[get_current_user] = lambda: user
+
+    def sessions():
+        with test_db() as session:
+            yield session
+
+    app.dependency_overrides[session_dependency] = sessions
+    return TestClient(app)
+
+
+def test_manifest_fixture_round_trips_and_rejects_invalid_schema():
+    raw = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    manifest = ExtensionManifest.model_validate(raw)
+    assert manifest.capabilities[0].input_schema.required == ["submissionId"]
+    dumped = manifest.model_dump(by_alias=True, mode="json")
+    assert ExtensionManifest.model_validate(dumped) == manifest
+    assert dumped["extensionId"] == raw["extensionId"]
+
+    invalid = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    invalid["capabilities"][0]["inputSchema"]["required"] = ["missing"]
+    with pytest.raises(ValidationError, match="lack property definitions"):
+        ExtensionManifest.model_validate(invalid)
+
+    duplicate = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    duplicate["capabilities"].append(duplicate["capabilities"][0])
+    with pytest.raises(ValidationError, match="must be unique"):
+        ExtensionManifest.model_validate(duplicate)
+
+
+def test_admin_installs_manifest_and_manages_declared_grant(test_db):
+    admin = User(
+        id=uuid4(), name="Admin", email=f"{uuid4()}@example.test", role=UserRole.admin
+    )
+    with test_db() as session:
+        session.add(admin)
+        session.commit()
+    client = _client(test_db, admin)
+    manifest = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    created = client.post("/api/v1/extensions/installations", json={"manifest": manifest})
+    assert created.status_code == 201, created.text
+    installation = created.json()
+    capability = installation["capabilities"][0]
+    assert capability["inputSchema"]["$id"] == "urn:fair:example:review-input"
+
+    grant = client.post("/api/v1/extensions/grants", json={
+        "installationId": installation["id"],
+        "capabilityDefinitionId": capability["id"],
+        "effect": "feedback:write",
+        "decision": "allow",
+        "reason": "Approved for this installation"
+    })
+    assert grant.status_code == 201, grant.text
+    assert grant.json()["grantedByUserId"] == str(admin.id)
+
+    undeclared = client.post("/api/v1/extensions/grants", json={
+        "installationId": installation["id"],
+        "capabilityDefinitionId": capability["id"],
+        "effect": "grades:write",
+        "decision": "allow"
+    })
+    assert undeclared.status_code == 422
+
+
+def test_non_admin_can_discover_enabled_capabilities_but_not_mutate(test_db):
+    admin = User(id=uuid4(), name="Admin", email=f"{uuid4()}@example.test", role=UserRole.admin)
+    user = User(id=uuid4(), name="User", email=f"{uuid4()}@example.test", role=UserRole.user)
+    with test_db() as session:
+        session.add_all([admin, user])
+        session.commit()
+    manifest = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    admin_client = _client(test_db, admin)
+    created = admin_client.post("/api/v1/extensions/installations", json={"manifest": manifest})
+    assert created.status_code == 201
+
+    user_client = _client(test_db, user)
+    capabilities = user_client.get("/api/v1/extensions/capabilities")
+    assert capabilities.status_code == 200
+    assert capabilities.json()[0]["capabilityId"] == "review.assignment"
+    denied = user_client.post("/api/v1/extensions/installations", json={"manifest": manifest})
+    assert denied.status_code == 403

--- a/tests/test_flows_api.py
+++ b/tests/test_flows_api.py
@@ -1,0 +1,152 @@
+from uuid import UUID, uuid4
+
+from fastapi.testclient import TestClient
+from sqlalchemy.dialects import postgresql
+
+from fair_platform.backend.api.routers.auth import get_current_user
+from fair_platform.backend.data.models import Execution, ExecutionDispatchOutbox, FlowVersion
+from fair_platform.backend.data.models.user import User, UserRole
+from fair_platform.backend.main import app
+from fair_platform.backend.services.flow_service import _flow_allocation_lock_statement
+
+
+def _user(test_db, email: str) -> User:
+    with test_db() as session:
+        user = User(
+            id=uuid4(),
+            name=email,
+            email=email,
+            role=UserRole.professor,
+            password_hash="unused",
+            is_verified=True,
+        )
+        session.add(user)
+        session.commit()
+        return user
+
+
+def _as_user(user: User):
+    app.dependency_overrides[get_current_user] = lambda: user
+
+
+def test_flow_crud_is_owner_scoped(test_db):
+    owner = _user(test_db, "flow-owner@example.test")
+    stranger = _user(test_db, "flow-stranger@example.test")
+    client = TestClient(app)
+
+    _as_user(owner)
+    created = client.post(
+        "/api/v1/flows", json={"name": "Grade submissions", "description": "v1"}
+    )
+    assert created.status_code == 201
+    flow_id = created.json()["id"]
+
+    updated = client.patch(
+        f"/api/v1/flows/{flow_id}", json={"name": "Grade deterministically"}
+    )
+    assert updated.status_code == 200
+    assert updated.json()["name"] == "Grade deterministically"
+    assert len(client.get("/api/v1/flows").json()) == 1
+
+    _as_user(stranger)
+    assert client.get(f"/api/v1/flows/{flow_id}").status_code == 404
+    assert client.patch(f"/api/v1/flows/{flow_id}", json={"name": "Mine"}).status_code == 404
+
+    _as_user(owner)
+    archived = client.delete(f"/api/v1/flows/{flow_id}")
+    assert archived.status_code == 200
+    assert archived.json()["archivedAt"] is not None
+    assert client.get("/api/v1/flows").json() == []
+    assert len(client.get("/api/v1/flows?include_archived=true").json()) == 1
+
+
+def test_flow_versions_are_ordered_and_have_explicit_lifecycle(test_db):
+    owner = _user(test_db, "version-owner@example.test")
+    _as_user(owner)
+    client = TestClient(app)
+    flow_id = client.post("/api/v1/flows", json={"name": "Ordered"}).json()["id"]
+
+    first = client.post(
+        f"/api/v1/flows/{flow_id}/versions",
+        json={"definition": {"nodes": [{"id": "one"}]}},
+    )
+    second = client.post(
+        f"/api/v1/flows/{flow_id}/versions",
+        json={"definition": {"nodes": [{"id": "one"}, {"id": "two"}]}},
+    )
+    assert first.status_code == second.status_code == 201
+    assert [first.json()["ordinal"], second.json()["ordinal"]] == [1, 2]
+    assert first.json()["definitionHash"] != second.json()["definitionHash"]
+
+    same_definition_with_pin = client.post(
+        f"/api/v1/flows/{flow_id}/versions",
+        json={
+            "definition": {"nodes": [{"id": "one"}]},
+            "capabilityPins": [{"capabilityId": "grade", "version": "1.0.0"}],
+            "configSnapshot": {"threshold": 0.8},
+        },
+    )
+    assert same_definition_with_pin.status_code == 201
+    assert same_definition_with_pin.json()["ordinal"] == 3
+    assert same_definition_with_pin.json()["definitionHash"] != first.json()["definitionHash"]
+
+    version_id = first.json()["id"]
+    published = client.post(f"/api/v1/flows/{flow_id}/versions/{version_id}/publish")
+    assert published.status_code == 200
+    assert published.json()["state"] == "published"
+    assert client.post(f"/api/v1/flows/{flow_id}/versions/{version_id}/publish").status_code == 409
+
+    archived = client.post(f"/api/v1/flows/{flow_id}/versions/{version_id}/archive")
+    assert archived.status_code == 200
+    assert archived.json()["state"] == "archived"
+    assert client.post(f"/api/v1/flows/{flow_id}/versions/{version_id}/archive").status_code == 409
+
+    with test_db() as session:
+        stored = session.get(FlowVersion, UUID(version_id))
+        assert stored is not None
+        stored.definition = {"nodes": []}
+        try:
+            session.flush()
+        except ValueError:
+            session.rollback()
+        else:
+            raise AssertionError("archived FlowVersion accepted a content mutation")
+
+
+def test_flow_version_ordinal_allocation_locks_flow_on_postgresql():
+    statement = _flow_allocation_lock_statement(uuid4())
+    sql = str(statement.compile(dialect=postgresql.dialect()))
+    assert "FOR UPDATE" in sql
+
+
+def test_start_flow_creates_pinned_root_execution_and_outbox(test_db):
+    owner = _user(test_db, "execution-owner@example.test")
+    _as_user(owner)
+    client = TestClient(app)
+    flow_id = client.post("/api/v1/flows", json={"name": "Executable"}).json()["id"]
+    draft = client.post(
+        f"/api/v1/flows/{flow_id}/versions",
+        json={"definition": {"nodes": [{"id": "step", "capability": "grade"}]}},
+    ).json()
+
+    assert client.post(f"/api/v1/flows/{flow_id}/executions", json={}).status_code == 409
+    client.post(f"/api/v1/flows/{flow_id}/versions/{draft['id']}/publish")
+    started = client.post(
+        f"/api/v1/flows/{flow_id}/executions",
+        json={"flowVersionId": draft["id"], "input": {"submissionId": "s-1"}},
+    )
+    assert started.status_code == 202
+    body = started.json()
+    assert body["flowVersionId"] == draft["id"]
+    assert body["status"] == "queued"
+
+    with test_db() as session:
+        execution = session.get(Execution, UUID(body["executionId"]))
+        dispatch = session.get(ExecutionDispatchOutbox, UUID(body["dispatchId"]))
+        assert execution is not None
+        assert execution.root_execution_id == execution.id
+        assert str(execution.flow_version_id) == draft["id"]
+        assert execution.input == {"submissionId": "s-1"}
+        assert dispatch is not None
+        assert dispatch.target == "flow.executor"
+        assert dispatch.payload["flowVersionId"] == draft["id"]

--- a/tests/test_legacy_cutover_contract.py
+++ b/tests/test_legacy_cutover_contract.py
@@ -1,0 +1,187 @@
+"""Executable checklist for removing the pre-1.0 execution stack.
+
+The inventory tests prevent an unlisted legacy surface from being added.  The
+stage checks intentionally fail until every route and source file in that stage
+has been removed.  Delete stages in numeric order; historical Alembic revisions
+are deliberately not part of the source-removal inventory.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from fair_platform.backend.main import app
+
+
+REPO_ROOT = Path(__file__).parents[1]
+BACKEND_ROOT = REPO_ROOT / "src/fair_platform/backend"
+
+
+@dataclass(frozen=True)
+class CutoverStage:
+    number: int
+    name: str
+    depends_on: tuple[str, ...]
+    routes: tuple[str, ...] = ()
+    files: tuple[str, ...] = ()
+
+
+CUTOVER_STAGES = (
+    CutoverStage(
+        1,
+        "workflow-run public adapter",
+        (
+            "Execution create/read/event/stream APIs cover all callers",
+            "submission code no longer imports WorkflowRun schemas or services",
+        ),
+        routes=(
+            "/api/workflow-runs/",
+            "/api/workflow-runs/{workflow_run_id}",
+            "/api/workflow-runs/{workflow_run_id}/stream",
+        ),
+        files=(
+            "api/routers/workflow_runs.py",
+            "api/schema/workflow_run.py",
+        ),
+    ),
+    CutoverStage(
+        2,
+        "workflow definitions and runner",
+        (
+            "stage 1 is complete",
+            "Flow and FlowVersion APIs own ordered definitions",
+            "Execution dispatch no longer calls WorkflowRunner",
+        ),
+        routes=(
+            "/api/workflows/",
+            "/api/workflows/{workflow_id}",
+        ),
+        files=(
+            "api/routers/workflows.py",
+            "api/schema/workflow.py",
+            "data/models/workflow.py",
+            "data/models/workflow_run.py",
+            "services/workflow_runner.py",
+        ),
+    ),
+    CutoverStage(
+        3,
+        "public Job transport",
+        (
+            "stages 1 and 2 are complete",
+            "execution outbox dispatcher is the only work-delivery entrypoint",
+            "extensions acknowledge commands and append Execution events",
+        ),
+        routes=(
+            "/api/jobs/",
+            "/api/jobs/{job_id}",
+            "/api/jobs/{job_id}/stream",
+            "/api/jobs/{job_id}/updates",
+        ),
+        files=(
+            "api/dependencies/job_queue.py",
+            "api/routers/jobs.py",
+            "api/schema/job.py",
+            "services/job_dispatcher.py",
+            "services/job_queue.py",
+        ),
+    ),
+    CutoverStage(
+        4,
+        "Plugin compatibility resources",
+        (
+            "stages 1 through 3 are complete",
+            "Extension installation/capability APIs replace plugin discovery",
+            "frontend and assignments persist extension/capability identities",
+        ),
+        routes=(
+            "/api/plugins/",
+            "/api/plugins/{plugin_id}",
+        ),
+        files=(
+            "api/routers/plugins.py",
+            "api/schema/plugin.py",
+        ),
+    ),
+)
+
+DECLARED_LEGACY_ROUTES = {
+    route for stage in CUTOVER_STAGES for route in stage.routes
+}
+DECLARED_LEGACY_FILES = {
+    file for stage in CUTOVER_STAGES for file in stage.files
+}
+LEGACY_ROUTE_PREFIXES = (
+    "/api/workflows",
+    "/api/workflow-runs",
+    "/api/jobs",
+    "/api/plugins",
+)
+
+
+def _openapi_legacy_routes() -> set[str]:
+    return {
+        path
+        for path in app.openapi()["paths"]
+        if path.startswith(LEGACY_ROUTE_PREFIXES)
+    }
+
+
+def _discover_named_legacy_files() -> set[str]:
+    candidates = set()
+    for path in BACKEND_ROOT.rglob("*.py"):
+        relative = path.relative_to(BACKEND_ROOT).as_posix()
+        if relative.startswith("alembic/"):
+            continue
+        name = path.stem
+        if "workflow" in name or name in {
+            "job",
+            "jobs",
+            "job_queue",
+            "job_dispatcher",
+            "plugin",
+            "plugins",
+        }:
+            candidates.add(relative)
+    return candidates
+
+
+def test_openapi_legacy_inventory_has_no_unlisted_surfaces() -> None:
+    unlisted = _openapi_legacy_routes() - DECLARED_LEGACY_ROUTES
+    assert not unlisted, f"Add unlisted legacy routes to a cutover stage: {sorted(unlisted)}"
+
+
+def test_source_legacy_inventory_has_no_unlisted_files() -> None:
+    unlisted = _discover_named_legacy_files() - DECLARED_LEGACY_FILES
+    assert not unlisted, f"Add unlisted legacy files to a cutover stage: {sorted(unlisted)}"
+
+
+@pytest.mark.parametrize("stage", CUTOVER_STAGES, ids=lambda stage: f"stage-{stage.number}-{stage.name}")
+def test_legacy_cutover_stage_is_complete(stage: CutoverStage) -> None:
+    remaining_routes = sorted(set(stage.routes) & _openapi_legacy_routes())
+    remaining_files = sorted(
+        file for file in stage.files if (BACKEND_ROOT / file).is_file()
+    )
+    if remaining_routes or remaining_files:
+        # Imperative pytest.xfail is non-strict: it keeps the suite green now and
+        # naturally becomes an ordinary pass once this stage has no remnants.
+        pytest.xfail(
+            f"Cutover stage {stage.number} ({stage.name}) is not complete. "
+            f"Dependencies: {'; '.join(stage.depends_on)}. "
+            f"Remaining routes: {remaining_routes}. Remaining files: {remaining_files}."
+        )
+
+
+def test_legacy_cutover_is_complete() -> None:
+    remaining_routes = sorted(_openapi_legacy_routes())
+    remaining_files = sorted(
+        file for file in DECLARED_LEGACY_FILES if (BACKEND_ROOT / file).is_file()
+    )
+    if remaining_routes or remaining_files:
+        pytest.xfail(
+            "Legacy cutover is not complete. Complete the four ordered stage gates. "
+            f"Remaining routes: {remaining_routes}. Remaining files: {remaining_files}."
+        )


### PR DESCRIPTION
## Summary

- adds owner-scoped Flow and immutable FlowVersion APIs
- starts pinned Flow Executions through the durable outbox
- adds validated Extension manifests, installations, capabilities, and grants under `/api/v1/extensions`
- keeps the existing extension registry explicitly isolated as legacy code
- adds executable dependency-ordered gates for removing WorkflowRun, Workflow, public Job, and Plugin surfaces
- avoids semantic version suffixes in first-party filenames

## Validation

- focused foundation suite: 41 passed, 5 expected legacy-cutover xfails
- Flow API: 4 passed
- Extension contracts/resources: 3 passed
- Ruff: passed
- git diff check: passed

## Cutover order

1. switch WorkflowRun consumers to Execution
2. switch Workflow definitions/runner to Flow
3. remove public Job transport after durable dispatch owns delivery
4. remove Plugin compatibility after Extension resources own discovery/configuration
