### PR TITLE
Fix startup for pre-merge LMS databases

### DIFF
--- a/src/fair_platform/backend/alembic/versions/20260713_0021_legacy_lms_head.py
+++ b/src/fair_platform/backend/alembic/versions/20260713_0021_legacy_lms_head.py
@@ -1,0 +1,30 @@
+"""Recognize databases migrated by the original LMS PR lineage.
+
+Revision ID: 20260713_0021
+Revises: 20260711_0017
+
+PR #204 originally shipped LMS revisions 20260713_0018 through
+20260713_0021. During integration those identifiers collided with the
+thin-core cutover and the LMS revisions were rebased to 20260714_0021
+through 20260714_0024. Existing local databases can still legitimately be
+stamped at this historical head, so this no-op branch keeps that state
+addressable by Alembic.
+"""
+
+from collections.abc import Sequence
+
+
+revision: str = "20260713_0021"
+down_revision: str | None = "20260711_0017"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "20260713_0021 is a historical compatibility marker and cannot be downgraded"
+    )

--- a/src/fair_platform/backend/alembic/versions/20260714_0021_lms_course_memberships.py
+++ b/src/fair_platform/backend/alembic/versions/20260714_0021_lms_course_memberships.py
@@ -20,7 +20,31 @@ branch_labels = None
 depends_on = None
 
 
+def _column_names(table_name: str) -> set[str]:
+    return {
+        column["name"] for column in sa.inspect(op.get_bind()).get_columns(table_name)
+    }
+
+
 def upgrade() -> None:
+    expected_course_columns = {
+        "section",
+        "term",
+        "is_archived",
+        "created_at",
+        "updated_at",
+    }
+    expected_enrollment_columns = {"role", "status", "updated_at"}
+    course_columns = _column_names("courses")
+    enrollment_columns = _column_names("enrollments")
+    present = (expected_course_columns & course_columns) | (
+        expected_enrollment_columns & enrollment_columns
+    )
+    if expected_course_columns <= course_columns and expected_enrollment_columns <= enrollment_columns:
+        return
+    if present:
+        raise RuntimeError("LMS course-membership migration is only partially applied")
+
     with op.batch_alter_table("courses") as batch_op:
         batch_op.add_column(sa.Column("section", sa.String(length=128), nullable=True))
         batch_op.add_column(sa.Column("term", sa.String(length=128), nullable=True))

--- a/src/fair_platform/backend/alembic/versions/20260714_0022_lms_assignment_submissions.py
+++ b/src/fair_platform/backend/alembic/versions/20260714_0022_lms_assignment_submissions.py
@@ -15,7 +15,25 @@ branch_labels = None
 depends_on = None
 
 
+def _column_names(table_name: str) -> set[str]:
+    return {
+        column["name"] for column in sa.inspect(op.get_bind()).get_columns(table_name)
+    }
+
+
 def upgrade() -> None:
+    expected_assignment_columns = {"status", "published_at", "allow_resubmissions"}
+    expected_submission_columns = {"attempt_number", "is_late"}
+    assignment_columns = _column_names("assignments")
+    submission_columns = _column_names("submissions")
+    present = (expected_assignment_columns & assignment_columns) | (
+        expected_submission_columns & submission_columns
+    )
+    if expected_assignment_columns <= assignment_columns and expected_submission_columns <= submission_columns:
+        return
+    if present:
+        raise RuntimeError("LMS assignment/submission migration is only partially applied")
+
     with op.batch_alter_table("assignments") as batch_op:
         batch_op.add_column(
             sa.Column("status", sa.String(length=32), server_default="published", nullable=False)

--- a/src/fair_platform/backend/alembic/versions/20260714_0023_lms_communication.py
+++ b/src/fair_platform/backend/alembic/versions/20260714_0023_lms_communication.py
@@ -15,7 +15,22 @@ branch_labels = None
 depends_on = None
 
 
+EXPECTED_TABLES = {
+    "course_posts",
+    "course_post_artifacts",
+    "course_comments",
+    "notifications",
+}
+
+
 def upgrade() -> None:
+    existing_tables = set(sa.inspect(op.get_bind()).get_table_names())
+    present = EXPECTED_TABLES & existing_tables
+    if present == EXPECTED_TABLES:
+        return
+    if present:
+        raise RuntimeError("LMS communication migration is only partially applied")
+
     op.create_table(
         "course_posts",
         sa.Column("id", sa.UUID(), nullable=False),

--- a/src/fair_platform/backend/alembic/versions/20260714_0024_lms_submission_comments.py
+++ b/src/fair_platform/backend/alembic/versions/20260714_0024_lms_submission_comments.py
@@ -16,6 +16,9 @@ depends_on = None
 
 
 def upgrade() -> None:
+    if "submission_comments" in sa.inspect(op.get_bind()).get_table_names():
+        return
+
     op.create_table(
         "submission_comments",
         sa.Column("id", sa.UUID(), nullable=False),

--- a/src/fair_platform/backend/alembic/versions/20260714_0025_merge_legacy_lms_lineage.py
+++ b/src/fair_platform/backend/alembic/versions/20260714_0025_merge_legacy_lms_lineage.py
@@ -1,0 +1,23 @@
+"""Merge the historical LMS and integrated thin-core lineages.
+
+Revision ID: 20260714_0025
+Revises: 20260714_0024, 20260713_0021
+"""
+
+from collections.abc import Sequence
+
+
+revision: str = "20260714_0025"
+down_revision: tuple[str, str] = ("20260714_0024", "20260713_0021")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "20260714_0025 merges an intentional destructive cutover and cannot be downgraded"
+    )

--- a/src/fair_platform/cli/main.py
+++ b/src/fair_platform/cli/main.py
@@ -1,4 +1,6 @@
 import multiprocessing
+import os
+import signal
 import subprocess
 import tomllib
 import json
@@ -95,7 +97,12 @@ def _start_backend_process(port: int, headless: bool) -> multiprocessing.Process
 
 def _start_frontend_process(frontend_dir: Path) -> subprocess.Popen:
     try:
-        return subprocess.Popen(["bun", "dev"], cwd=frontend_dir)
+        process_options = (
+            {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+            if _is_windows()
+            else {"start_new_session": True}
+        )
+        return subprocess.Popen(["bun", "dev"], cwd=frontend_dir, **process_options)
     except FileNotFoundError as exc:
         typer.echo(
             "Error: bun is required to run the frontend dev server. Install Bun from https://bun.sh."
@@ -112,14 +119,38 @@ def _stop_backend(process: multiprocessing.Process) -> None:
         process.join(timeout=5)
 
 
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
 def _stop_frontend(process: subprocess.Popen) -> None:
-    if process.poll() is None:
-        process.terminate()
+    if process.poll() is not None:
+        return
+
+    if _is_windows():
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         try:
             process.wait(timeout=5)
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait(timeout=5)
+        return
+
+    try:
+        process_group = os.getpgid(process.pid)
+        os.killpg(process_group, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(process_group, signal.SIGKILL)
+        process.wait(timeout=5)
 
 
 def version_callback(value: bool):

--- a/src/fair_platform/cli/main.py
+++ b/src/fair_platform/cli/main.py
@@ -36,6 +36,7 @@ def _get_version() -> str:
 
 __version__ = _get_version()
 _PROCESS_POLL_INTERVAL_SECONDS = 0.5
+_CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
 _DATA_TABLE_ORDER = [
     "users",
     "plugins",
@@ -98,7 +99,7 @@ def _start_backend_process(port: int, headless: bool) -> multiprocessing.Process
 def _start_frontend_process(frontend_dir: Path) -> subprocess.Popen:
     try:
         process_options = (
-            {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+            {"creationflags": _CREATE_NEW_PROCESS_GROUP}
             if _is_windows()
             else {"start_new_session": True}
         )

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -143,7 +143,7 @@ def test_frontend_starts_in_a_separate_windows_process_group(monkeypatch, tmp_pa
 
     assert cli_main._start_frontend_process(tmp_path) is frontend
     assert captured["command"] == ["bun", "dev"]
-    assert captured["kwargs"]["creationflags"] == cli_main.subprocess.CREATE_NEW_PROCESS_GROUP
+    assert captured["kwargs"]["creationflags"] == cli_main._CREATE_NEW_PROCESS_GROUP
 
 
 def test_frontend_shutdown_kills_windows_process_tree(monkeypatch):

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -30,6 +30,25 @@ class InterruptingBackendProcess(StubBackendProcess):
         raise KeyboardInterrupt
 
 
+class StubFrontendProcess:
+    pid = 4321
+
+    def __init__(self):
+        self.returncode = None
+        self.wait_calls = []
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        self.wait_calls.append(timeout)
+        self.returncode = 0
+        return self.returncode
+
+    def kill(self):
+        self.returncode = -9
+
+
 def test_dev_command_runs_backend_only_when_frontend_disabled(monkeypatch):
     runner = CliRunner()
     backend_calls = {}
@@ -108,6 +127,40 @@ def test_dev_command_handles_keyboard_interrupt(monkeypatch):
 
     assert result.exit_code == 0
     assert backend in stopped
+
+
+def test_frontend_starts_in_a_separate_windows_process_group(monkeypatch, tmp_path):
+    captured = {}
+    frontend = StubFrontendProcess()
+
+    def fake_popen(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return frontend
+
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(cli_main.subprocess, "Popen", fake_popen)
+
+    assert cli_main._start_frontend_process(tmp_path) is frontend
+    assert captured["command"] == ["bun", "dev"]
+    assert captured["kwargs"]["creationflags"] == cli_main.subprocess.CREATE_NEW_PROCESS_GROUP
+
+
+def test_frontend_shutdown_kills_windows_process_tree(monkeypatch):
+    frontend = StubFrontendProcess()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+
+    cli_main._stop_frontend(frontend)
+
+    assert calls[0][0] == ["taskkill", "/PID", "4321", "/T", "/F"]
+    assert calls[0][1]["check"] is False
+    assert frontend.wait_calls == [5]
 
 
 def test_db_upgrade_command_invokes_alembic(monkeypatch):

--- a/tests/test_migration_rehearsal_files.py
+++ b/tests/test_migration_rehearsal_files.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import importlib
 import sqlite3
 from pathlib import Path
 
 from alembic import command
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
 from alembic.script import ScriptDirectory
 import pytest
+from sqlalchemy import create_engine, inspect, text
 
 from fair_platform.backend.data.migrations import (
     build_alembic_config,
@@ -15,6 +19,13 @@ from fair_platform.backend.data.migrations import (
 
 
 REHEARSAL_OLD_REVISION = "20260203_0003"
+PRE_MERGE_LMS_REVISION = "20260713_0021"
+PRE_MERGE_LMS_MIGRATIONS = (
+    "20260714_0021_lms_course_memberships",
+    "20260714_0022_lms_assignment_submissions",
+    "20260714_0023_lms_communication",
+    "20260714_0024_lms_submission_comments",
+)
 
 
 def _alembic_head() -> str:
@@ -52,6 +63,47 @@ def test_upgrade_rehearsal_head_to_head_is_idempotent(tmp_path: Path) -> None:
 
     assert first == _alembic_head()
     assert second == first
+
+
+def test_upgrade_rehearsal_from_pre_merge_lms_head(tmp_path: Path) -> None:
+    db_path = tmp_path / "rehearsal_pre_merge_lms.sqlite"
+    database_url = f"sqlite:///{db_path.as_posix()}"
+    run_migrations_to_revision("20260711_0017", database_url)
+
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        for migration_name in PRE_MERGE_LMS_MIGRATIONS:
+            migration = importlib.import_module(
+                "fair_platform.backend.alembic.versions." + migration_name
+            )
+            original_op = migration.op
+            migration.op = operations
+            try:
+                migration.upgrade()
+            finally:
+                migration.op = original_op
+        connection.execute(
+            text("UPDATE alembic_version SET version_num = :revision"),
+            {"revision": PRE_MERGE_LMS_REVISION},
+        )
+    engine.dispose()
+
+    run_migrations_to_head(database_url)
+
+    engine = create_engine(database_url)
+    with engine.connect() as connection:
+        schema = inspect(connection)
+        tables = set(schema.get_table_names())
+        execution_columns = {
+            column["name"] for column in schema.get_columns("executions")
+        }
+        assert _read_revision(db_path) == _alembic_head()
+        assert {"course_posts", "submission_comments"} <= tables
+        assert {"course_id", "assignment_id"} <= execution_columns
+        assert "workflows" not in tables
+        assert "workflow_runs" not in tables
+    engine.dispose()
 
 
 def test_destructive_cutover_rejects_downgrade(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- recognize the historical `20260713_0021` LMS migration head created before PR #204 was integrated
- merge that historical lineage with the rebased thin-core/LMS lineage at a single `20260714_0025` head
- make the rebased LMS schema migrations safely idempotent when the historical LMS schema is already present
- add a migration rehearsal that recreates the pre-merge LMS state and upgrades it through the thin-core cutover

## Root cause

PR #204 originally used revision IDs `20260713_0018` through `20260713_0021`. PR #205 independently used overlapping IDs during the thin-core cutover. The integration rebased the LMS revisions to `20260714_0021` through `20260714_0024`, leaving existing local databases stamped at `20260713_0021` on an unrecognized Alembic lineage. Startup therefore failed with `Can't locate revision identified by '20260713_0021'`.

## Safety

The historical revision is represented as a no-op compatibility marker. Upgrading from it still executes the thin-core cutover, while the LMS migrations detect the already-present LMS schema and avoid duplicate columns or tables. Fresh databases continue through the canonical branch and converge at the same merge head.

The local application database was backed up before rehearsal and upgraded successfully without deleting LMS tables.

## Verification

- `98 passed, 1 skipped` across migration/startup, LMS, Flow/Execution, artifact, foundation, and cutover tests
- dedicated pre-merge LMS migration rehearsal passes
- Ruff passes for all changed migration/test files
- Alembic reports one head: `20260714_0025`
- `fair dev --port 8010`: backend `/health` 200 and Vite app root 200
- frontend: 3 tests passed; Vite production build passed
- `uv build`: wheel and source distribution built successfully
- `fair serve --port 8011 --no-update-check`: `/health` 200 and bundled app root 200


## Windows dev shutdown follow-up

- start the frontend in a separate process group
- terminate the complete Bun/Vite/Node/esbuild tree with `taskkill /T` on Windows
- use a process session and process-group signals on POSIX
- add CLI tests for Windows process-group startup and tree shutdown

Additional verification: two real Vite start/stop cycles completed with no frontend listener or workspace process left behind.
