### PR TITLE
Fix instructor membership actions

### DIFF
--- a/frontend-dev/src/app/courses/tabs/participants-tab.test.tsx
+++ b/frontend-dev/src/app/courses/tabs/participants-tab.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mutations = vi.hoisted(() => ({
+  remove: vi.fn(),
+  updateRole: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-courses", () => ({
+  useCourseEnrollments: () => ({
+    data: [
+      {
+        id: "assistant-enrollment",
+        userId: "assistant-user",
+        courseId: "course-1",
+        role: "assistant",
+        status: "active",
+        userName: "Alex Assistant",
+        userEmail: "alex@example.com",
+      },
+    ],
+    isLoading: false,
+  }),
+  useRemoveEnrollment: () => ({ mutate: mutations.remove }),
+  useUpdateEnrollmentRole: () => ({ mutate: mutations.updateRole }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { ParticipantsTab } from "./participants-tab";
+
+describe("ParticipantsTab", () => {
+  beforeEach(() => {
+    mutations.remove.mockClear();
+    mutations.updateRole.mockClear();
+  });
+
+  it("lets a course owner demote and remove an assistant", () => {
+    render(
+      <ParticipantsTab
+        courseId="course-1"
+        instructor={{
+          id: "owner-user",
+          name: "Course Owner",
+          email: "owner@example.com",
+          role: "owner",
+        }}
+        canManageRoles
+      />,
+    );
+
+    const actionButtons = screen.getAllByRole("button");
+    fireEvent.pointerDown(actionButtons[1], { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByText("Make student"));
+
+    expect(mutations.updateRole).toHaveBeenCalledWith({
+      id: "assistant-enrollment",
+      role: "student",
+    });
+
+    fireEvent.pointerDown(actionButtons[1], { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByText("Remove from course"));
+
+    expect(mutations.remove).toHaveBeenCalledWith("assistant-enrollment");
+  });
+});

--- a/frontend-dev/src/app/courses/tabs/participants-tab.tsx
+++ b/frontend-dev/src/app/courses/tabs/participants-tab.tsx
@@ -20,6 +20,7 @@ import {
 
 type Instructor = {
   id: string;
+  enrollmentId?: string;
   name: string;
   email: string;
   role: string;
@@ -44,6 +45,7 @@ export function ParticipantsTab({
       ...(instructor ? [instructor] : []),
       ...assistants.map((membership) => ({
         id: membership.userId,
+        enrollmentId: membership.id,
         name: membership.userName ?? 'Assistant',
         email: membership.userEmail ?? '',
         role: 'assistant',
@@ -85,22 +87,43 @@ export function ParticipantsTab({
       {
         id: "actions",
         header: () => <div className="w-12 text-right">{t("actions.courseActions")}</div>,
-        cell: () => (
+        cell: ({ row }) => (
           <div className="text-right">
             <DropdownMenu>
               <DropdownMenuTrigger className="ml-auto flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted">
                 <Ellipsis className="h-4 w-4" />
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem disabled>View profile</DropdownMenuItem>
-                <DropdownMenuItem disabled>{t("common.edit")}</DropdownMenuItem>
+                {row.original.enrollmentId && canManageRoles ? (
+                  <>
+                    <DropdownMenuItem
+                      onClick={() => updateRole.mutate({
+                        id: row.original.enrollmentId!,
+                        role: 'student',
+                      })}
+                    >
+                      Make student
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="text-destructive"
+                      onClick={() => removeEnrollment.mutate(row.original.enrollmentId!)}
+                    >
+                      Remove from course
+                    </DropdownMenuItem>
+                  </>
+                ) : (
+                  <>
+                    <DropdownMenuItem disabled>View profile</DropdownMenuItem>
+                    <DropdownMenuItem disabled>{t("common.edit")}</DropdownMenuItem>
+                  </>
+                )}
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
         ),
       },
     ],
-    [t],
+    [canManageRoles, removeEnrollment, t, updateRole],
   );
 
   const studentColumns = useMemo<ColumnDef<EnrollmentSummary>[]>(


### PR DESCRIPTION
Summary: preserves assistant enrollment IDs in the Participants tab; lets course owners and admins demote assistants to students or remove them; keeps the course owner protected. Validation: focused ParticipantsTab Vitest regression passed; frontend production build passed.