### PR TITLE
Fix revised grade returns and student visibility

### DIFF
--- a/frontend-dev/src/app/assignment/components/submissions/student-submission-grade.test.tsx
+++ b/frontend-dev/src/app/assignment/components/submissions/student-submission-grade.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      key === "submissions.grade" ? "Grade" : "Feedback",
+  }),
+}));
+
+import { Submission } from "@/hooks/use-submissions";
+import { StudentSubmissionGrade } from "./student-submission-grade";
+
+afterEach(cleanup);
+
+const submission = {
+  id: "submission-1",
+  assignmentId: "assignment-1",
+  submitterId: "submitter-1",
+  submittedAt: "2026-07-27T12:00:00Z",
+  status: "returned",
+  artifacts: [],
+  attemptNumber: 1,
+  isLate: false,
+} satisfies Submission;
+
+describe("StudentSubmissionGrade", () => {
+  it("shows the published grade and feedback returned to the student", () => {
+    render(
+      <StudentSubmissionGrade
+        submission={{
+          ...submission,
+          draftScore: null,
+          draftFeedback: null,
+          publishedScore: 91,
+          publishedFeedback: "Clear argument",
+          returnedAt: "2026-07-27T13:00:00Z",
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("published-grade")).toHaveTextContent("91");
+    expect(screen.getByTestId("published-feedback")).toHaveTextContent(
+      "Clear argument",
+    );
+  });
+
+  it("does not expose an unreturned draft result", () => {
+    const { container } = render(
+      <StudentSubmissionGrade
+        submission={{
+          ...submission,
+          status: "graded",
+          draftScore: 88,
+          draftFeedback: "Draft feedback",
+        }}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend-dev/src/app/assignment/components/submissions/student-submission-grade.tsx
+++ b/frontend-dev/src/app/assignment/components/submissions/student-submission-grade.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from "react-i18next";
+
+import { Submission } from "@/hooks/use-submissions";
+
+export function StudentSubmissionGrade({
+  submission,
+}: {
+  submission: Submission;
+}) {
+  const { t } = useTranslation();
+  const hasPublishedResult =
+    submission.returnedAt != null ||
+    submission.publishedScore != null ||
+    submission.publishedFeedback != null;
+
+  if (!hasPublishedResult) return null;
+
+  return (
+    <dl className="mb-3 grid gap-2 rounded-md border bg-background p-3">
+      <div className="flex items-baseline justify-between gap-4">
+        <dt className="font-medium">{t("submissions.grade")}</dt>
+        <dd data-testid="published-grade">
+          {submission.publishedScore ?? "—"}
+        </dd>
+      </div>
+      {submission.publishedFeedback != null &&
+        submission.publishedFeedback !== "" && (
+          <div className="space-y-1">
+            <dt className="font-medium">{t("submissions.feedback")}</dt>
+            <dd
+              className="whitespace-pre-wrap text-muted-foreground"
+              data-testid="published-feedback"
+            >
+              {submission.publishedFeedback}
+            </dd>
+          </div>
+        )}
+    </dl>
+  );
+}

--- a/frontend-dev/src/app/assignment/components/submissions/submission-sheet.tsx
+++ b/frontend-dev/src/app/assignment/components/submissions/submission-sheet.tsx
@@ -23,6 +23,7 @@ import {
 
 import {
   Submission,
+  hasUnpublishedDraft,
   useSubmissionTimeline,
   useReturnSubmission,
 } from "@/hooks/use-submissions";
@@ -60,10 +61,8 @@ export function SubmissionSheet({
 
   if (!submission) return null;
 
-  const hasDraft =
-    submission.draftScore != null || submission.draftFeedback != null;
   const canReturn =
-    hasDraft && submission.status !== "returned" && !returnSubmission.isPending;
+    hasUnpublishedDraft(submission) && !returnSubmission.isPending;
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>

--- a/frontend-dev/src/app/assignment/components/submissions/submissions-table.tsx
+++ b/frontend-dev/src/app/assignment/components/submissions/submissions-table.tsx
@@ -24,6 +24,7 @@ import {
 import {
   Submission,
   SubmissionStatus,
+  hasUnpublishedDraft,
   useReturnSubmissions,
 } from "@/hooks/use-submissions";
 import { SubmissionSheet } from "@/app/assignment/components/submissions/submission-sheet";
@@ -130,11 +131,7 @@ function SubmissionsToolbar({
   const returnableSubmissionIds = table
     .getSelectedRowModel()
     .rows.map((row) => row.original)
-    .filter(
-      (submission) =>
-        submission.status !== "returned" &&
-        (submission.draftScore != null || submission.draftFeedback != null),
-    )
+    .filter(hasUnpublishedDraft)
     .map((submission) => submission.id);
 
   const hasReturnableSelection = returnableSubmissionIds.length > 0;

--- a/frontend-dev/src/app/assignment/components/submissions/submissions.tsx
+++ b/frontend-dev/src/app/assignment/components/submissions/submissions.tsx
@@ -37,6 +37,7 @@ import {
 import {
   SubmissionStatus,
   Submission,
+  hasUnpublishedDraft,
   useReturnSubmission,
   useUpdateSubmissionDraft,
 } from "@/hooks/use-submissions";
@@ -430,10 +431,8 @@ function SubmissionActionsCell({ submission }: { submission: Submission }) {
   const startFlow = useStartFlow();
   const returnSubmission = useReturnSubmission();
 
-  const hasDraft =
-    submission.draftScore != null || submission.draftFeedback != null;
   const canReturn =
-    hasDraft && submission.status !== "returned" && !returnSubmission.isPending;
+    hasUnpublishedDraft(submission) && !returnSubmission.isPending;
 
   function runFlow(flow?: Flow) {
     const version = latestPublishedVersion(flow);

--- a/frontend-dev/src/app/assignment/page.tsx
+++ b/frontend-dev/src/app/assignment/page.tsx
@@ -31,6 +31,7 @@ import { ArtifactAction } from "@/components/artifact-action";
 import { useAuth } from "@/contexts/auth-context";
 import { usePermission } from "@/hooks/use-permission";
 import { SubmissionComments } from "@/components/submission-comments";
+import { StudentSubmissionGrade } from "@/app/assignment/components/submissions/student-submission-grade";
 
 interface InstructorSubmissionsSectionProps {
   setIsCreateSubmissionOpen: (value: boolean) => void;
@@ -69,6 +70,7 @@ function StudentSubmissionSection({
             <span>{attempt.isLate ? 'Late' : attempt.status}</span>
           </summary>
           <div className="mt-3 border-t pt-3">
+            <StudentSubmissionGrade submission={attempt} />
             <SubmissionComments submissionId={attempt.id} />
           </div>
         </details>

--- a/frontend-dev/src/hooks/use-submissions.test.ts
+++ b/frontend-dev/src/hooks/use-submissions.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { hasUnpublishedDraft, Submission } from "./use-submissions";
+
+const submission = {
+  id: "submission-1",
+  assignmentId: "assignment-1",
+  submitterId: "submitter-1",
+  submittedAt: "2026-07-27T12:00:00Z",
+  status: "returned",
+  artifacts: [],
+  attemptNumber: 1,
+  isLate: false,
+  draftScore: 90,
+  draftFeedback: "Good work",
+  publishedScore: 90,
+  publishedFeedback: "Good work",
+} satisfies Submission;
+
+describe("hasUnpublishedDraft", () => {
+  it("is false immediately after a draft is returned", () => {
+    expect(hasUnpublishedDraft(submission)).toBe(false);
+  });
+
+  it("is true when an instructor changes a returned grade", () => {
+    expect(
+      hasUnpublishedDraft({
+        ...submission,
+        draftScore: 95,
+      }),
+    ).toBe(true);
+  });
+
+  it("is true when an instructor changes returned feedback", () => {
+    expect(
+      hasUnpublishedDraft({
+        ...submission,
+        draftFeedback: "Excellent revision",
+      }),
+    ).toBe(true);
+  });
+});

--- a/frontend-dev/src/hooks/use-submissions.ts
+++ b/frontend-dev/src/hooks/use-submissions.ts
@@ -99,6 +99,19 @@ export type UpdateSubmissionDraftInput = {
   feedback?: string | null
 }
 
+export function hasUnpublishedDraft(submission: Submission): boolean {
+  const hasDraft =
+    submission.draftScore != null || submission.draftFeedback != null
+
+  return (
+    hasDraft &&
+    (
+      submission.draftScore !== submission.publishedScore ||
+      submission.draftFeedback !== submission.publishedFeedback
+    )
+  )
+}
+
 export const submissionsKeys = {
   all: ['submissions'] as const,
   lists: () => [...submissionsKeys.all, 'list'] as const,

--- a/tests/test_lms_assignment_submission_lifecycle.py
+++ b/tests/test_lms_assignment_submission_lifecycle.py
@@ -238,3 +238,27 @@ def test_roster_gradebook_queue_and_returned_grade(test_client, test_db):
         "/api/lms/notifications", headers=_auth(test_client, student)
     ).json()
     assert notifications[0]["kind"] == "grade_returned"
+
+    revised = test_client.patch(
+        f"/api/submissions/{submission_id}/draft",
+        json={"score": 96, "feedback": "Revised after review"},
+        headers=_auth(test_client, owner),
+    )
+    assert revised.status_code == 200
+
+    returned_again = test_client.post(
+        f"/api/submissions/{submission_id}/return",
+        headers=_auth(test_client, owner),
+    )
+    assert returned_again.status_code == 200
+    assert returned_again.json()["publishedScore"] == 96
+    assert returned_again.json()["publishedFeedback"] == "Revised after review"
+
+    revised_student_view = test_client.get(
+        f"/api/submissions/{submission_id}",
+        headers=_auth(test_client, student),
+    ).json()
+    assert revised_student_view["publishedScore"] == 96
+    assert revised_student_view["publishedFeedback"] == "Revised after review"
+    assert revised_student_view["draftScore"] is None
+    assert revised_student_view["draftFeedback"] is None


### PR DESCRIPTION
## Summary

- allow instructors to return a submission again when its draft grade or feedback differs from the last published result
- apply the same unpublished-change rule to the submission sheet, row action, and bulk return action
- show students the published grade and feedback inside each returned attempt
- keep draft grades and feedback hidden from students

## Non-goals

- no grading schema or migration changes
- no change to the existing backend publication contract or authorization model
- no redesign of assignment grading scales

## Validation

- `bun run test -- src/hooks/use-submissions.test.ts src/app/assignment/components/submissions/student-submission-grade.test.tsx src/app/assignment/components/submissions/submissions-accessibility.test.tsx` — 6 passed
- `uv run --all-extras --no-sync pytest -q tests/test_lms_assignment_submission_lifecycle.py` — 4 passed
- `bun run build` — passed
- `git diff --check` — passed

## Review guide

1. Review `hasUnpublishedDraft` and its use across single and bulk return controls.
2. Review `StudentSubmissionGrade` and its placement in the student attempt details.
3. Review the frontend visibility tests and the end-to-end re-return lifecycle assertions.

## Next steps

- confirm repository CI on this branch
- manually smoke-test the instructor and student views in a shared deployed environment if desired
