### PR TITLE
Harden assignment dialog overflow handling

### DIFF
--- a/frontend-dev/src/app/courses/tabs/assignments/create-assignment-dialog.test.tsx
+++ b/frontend-dev/src/app/courses/tabs/assignments/create-assignment-dialog.test.tsx
@@ -13,6 +13,7 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => ({
       "common.add": "Add",
+      "common.cancel": "Cancel",
       "common.create": "Create",
       "assignments.addResources": "Add resources",
       "assignments.creating": "Creating",
@@ -38,7 +39,7 @@ describe("CreateAssignmentDialog", () => {
     });
   });
 
-  it("keeps the create footer outside the scrollable form body", () => {
+  it("keeps the actions outside a natively scrollable form body", () => {
     render(
       <CreateAssignmentDialog
         courseId="course-1"
@@ -49,13 +50,16 @@ describe("CreateAssignmentDialog", () => {
     );
 
     const dialog = screen.getByRole("dialog", { name: "New Assignment" });
-    const scrollArea = dialog.querySelector<HTMLElement>('[data-slot="scroll-area"]');
+    const scrollBody = dialog.querySelector<HTMLElement>('[data-slot="assignment-form-scroll"]');
     const footer = dialog.querySelector<HTMLElement>('[data-slot="dialog-footer"]');
+    const description = screen.getByLabelText("Description");
 
-    expect(dialog).toHaveClass("max-h-[calc(100vh-2rem)]");
-    expect(scrollArea).toHaveClass("min-h-0", "flex-1");
+    expect(dialog).toHaveClass("max-h-[calc(100dvh-2rem)]");
+    expect(scrollBody).toHaveClass("min-h-0", "flex-1", "overflow-y-auto");
+    expect(description).toHaveClass("max-h-64", "overflow-y-auto");
     expect(footer).toBeInTheDocument();
-    expect(scrollArea).not.toContainElement(footer);
+    expect(scrollBody).not.toContainElement(footer);
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
   });
 });

--- a/frontend-dev/src/app/courses/tabs/assignments/create-assignment-dialog.tsx
+++ b/frontend-dev/src/app/courses/tabs/assignments/create-assignment-dialog.tsx
@@ -2,6 +2,7 @@ import {useState, FormEvent, useRef} from "react";
 import {Button} from "@/components/ui/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogFooter,
   DialogHeader,
@@ -12,7 +13,6 @@ import {Input} from "@/components/ui/input";
 import {Label} from "@/components/ui/label";
 import {Textarea} from "@/components/ui/textarea";
 import {Plus, FileText, X} from "lucide-react";
-import {ScrollArea} from "@/components/ui/scroll-area";
 import { Assignment, useCreateAssignment, type CreateAssignmentInput } from "@/hooks/use-assignments";
 import {CreateAssignmentForm, Grade} from "@/app/courses/tabs/assignments/assignments";
 import {useTranslation} from "react-i18next";
@@ -149,7 +149,7 @@ export function CreateAssignmentDialog({
           {t("common.create")}
         </Button>
       </DialogTrigger>
-      <DialogContent className="flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden sm:max-w-[60%]">
+      <DialogContent className="flex max-h-[calc(100dvh-2rem)] flex-col gap-0 overflow-hidden sm:max-w-2xl">
         <DialogHeader className="shrink-0 pb-4">
           <DialogTitle>{t("assignments.newAssignment")}</DialogTitle>
         </DialogHeader>
@@ -157,7 +157,10 @@ export function CreateAssignmentDialog({
           className="flex min-h-0 flex-1 flex-col"
           onSubmit={handleSubmit}
         >
-          <ScrollArea className="min-h-0 flex-1 pr-3">
+          <div
+            data-slot="assignment-form-scroll"
+            className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pr-3"
+          >
             <div className="grid gap-4">
               <div className="grid gap-2">
                 <Label htmlFor="title">{t("assignments.titleLabel")}</Label>
@@ -174,6 +177,7 @@ export function CreateAssignmentDialog({
                 <Label htmlFor="description">{t("assignments.description")}</Label>
                 <Textarea
                   id="description"
+                  className="min-h-28 max-h-64 resize-y overflow-y-auto"
                   value={form.description}
                   onChange={e => setForm(f => ({...f, description: e.target.value}))}
                   placeholder={t("assignments.descriptionPlaceholder")}
@@ -251,9 +255,14 @@ export function CreateAssignmentDialog({
                 </div>
               ) : null}
             </div>
-          </ScrollArea>
+          </div>
 
-          <DialogFooter className="shrink-0 pt-4">
+          <DialogFooter className="shrink-0 border-t pt-4">
+            <DialogClose asChild>
+              <Button type="button" variant="outline" disabled={isPending}>
+                {t("common.cancel")}
+              </Button>
+            </DialogClose>
             <Button type="submit" disabled={isPending}>
               {isPending ? t("assignments.creating") : t("common.add")}
             </Button>


### PR DESCRIPTION
## Summary
- replace the Radix scroll wrapper with native overflow containment so auto-growing textareas contribute to the form's scroll range
- cap long descriptions inside a resizable, internally scrollable textarea
- use dynamic viewport height, a readable desktop width, and a separated fixed action footer
- add an explicit Cancel action and update the regression test

## Why this follows PR #219
Interactive testing of #219 found that its footer remained visible, but Radix's viewport wrapper did not include the auto-growing textarea in scrollHeight. With a very long description, lower fields were still clipped and unreachable. This follow-up closes that gap.

## Validation
- un run test -- --maxWorkers=1 (16 files, 28 tests passed)
- un x tsc --noEmit
- un run build
- browser-tested at 1440x900, 320x568, and 320x480
- verified a 120-paragraph description and a 50,000-character unbroken description
- verified the mobile body scrolls to lower fields while the footer remains visible
- successfully created the edge-case assignment (87 points, no due date)
- verified Cancel closes and resets the form