### PR TITLE
feat: add LMS foundation primitives

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -59,6 +59,7 @@
                 "pages": [
                   "en/platform/courses",
                   "en/platform/assignments",
+                  "en/platform/lms-primitives",
                   "en/platform/flows",
                   "en/platform/integrations",
                   "en/platform/settings"

--- a/docs/en/platform/lms-primitives.md
+++ b/docs/en/platform/lms-primitives.md
@@ -1,0 +1,71 @@
+---
+title: LMS foundation primitives
+description: Persistent contracts shared by FAIR's course builder, dashboards, gradebook, quizzes, and course copy features.
+---
+
+# LMS foundation primitives
+
+FAIR's LMS foundation is a normalized persistence contract for the next teaching features. It deliberately adds no end-user interface and no feature API. Feature services should build on these records instead of creating parallel course, grade, progress, identity, calendar, or audit tables.
+
+## Core invariants
+
+### Course structure
+
+`CourseSection` is an ordered container in one course. `CourseItem` is an ordered child that can represent a page, file, link, assignment, quiz, forum, or a future activity type.
+
+- Positions are stable non-negative integers and unique within their parent. Reordering should update all affected positions in one transaction.
+- Visibility is explicit: `draft`, `published`, or `hidden`.
+- A typed resource link uses the pair `resource_type` and `resource_id`. Both are present or both are absent. Core does not import or own future quiz, forum, or lesson models.
+- `payload_schema_uri` and `payload` hold versioned, type-specific display/configuration data. They are not an unversioned replacement for normalized feature data.
+- Composite foreign keys prevent an item from pointing to a section in another course.
+- Copyable sections and items retain `copied_from_id`. A course-copy service must remap resource IDs rather than silently carrying links to the source course.
+
+### Gradebook
+
+`GradeCategory`, `GradeItem`, and `GradeEntry` establish one points-only gradebook contract.
+
+- `GradeItem.max_points` and `GradeEntry.points_earned` are finite numeric point values. FAIR never persists percentages, letters, or pass/fail labels as grade values. Those are derived presentations or policy outputs.
+- Category and item weights, aggregation strategy, drop rules, extra-credit behavior, and similar calculations live in explicit policy metadata. Policy must not mutate the stored points.
+- Categories may form a course-scoped hierarchy. Items cannot attach to categories in another course.
+- Each learner has at most one current entry per grade item. The entry is `graded`, `missing`, or `excused`; missing and excused entries do not invent a zero-point score.
+- Release state is separate from grading state. Released entries require `released_at`; unreleased entries cannot carry it.
+- `source_type`, `source_id`, and `source_version` identify the fact projected into the gradebook. Assignment return should write only the returned/published points, atomically, with the submission as source. Draft submission scores never belong in `GradeEntry`.
+- Until the assignment migration is complete, `Submission.published_score` remains the compatibility source. Gradebook work must assert parity rather than choosing one value opportunistically.
+- Composite foreign keys require both the grade item and the enrolled learner to belong to the entry's course.
+
+### Completion and availability
+
+`CompletionRule` and `AvailabilityRule` are ordered, typed predicates with versionable JSON configuration. `UserItemCompletion` is the current learner projection (`not_started`, `in_progress`, or `completed`) and may retain typed source evidence.
+
+The foundation does not define rule evaluation. Future services must publish supported `rule_type` values, validate each configuration, and update projections transactionally. Cross-course items and users without an enrollment are rejected by database constraints.
+
+### Institutions and groups
+
+`Organization`, `OrganizationMembership`, `Cohort`, `CohortMembership`, `CourseGroup`, and `CourseGroupMembership` provide distinct institutional and course-local scopes.
+
+- A cohort member must already be a member of the same organization.
+- A course-group member must already be enrolled in the same course.
+- `ExternalIdentifier` maps a user, course, or cohort to an identifier from a named external system. The mapping is organization-scoped and identifies exactly one FAIR subject.
+- External identifiers are integration keys, not authentication credentials. Sync services remain responsible for authorization, conflict handling, and lifecycle policy.
+
+### Calendar, notifications, and activity
+
+`CalendarEvent` supports private and course-visible events, timezone labels, recurrence metadata, typed sources, and copy provenance. `NotificationPreference` records a user's delivery choice per channel and event type. Both retain nullable source pairs so course copy can remap generated records.
+
+`ActivityEvent` is an append-only fact with actor, course, organization, object, source, schema, and payload fields. ORM guards and database triggers reject updates and deletes. Corrections must be represented by a new event that references the earlier fact in its payload; event payloads should also record course-copy provenance when no dedicated `copied_from_id` exists.
+
+Activity events do not replace domain transactions or the execution event stream. Feature services decide which completed LMS actions deserve an activity event and must write them in the same transaction as the authoritative state whenever possible.
+
+## Intended rollout
+
+1. **Course builder (A1):** create sections/items and validate type-specific payloads and resource ownership.
+2. **Student dashboard (A2):** consume published items, released grades, completion projections, calendar events, and activity events.
+3. **Gradebook 2.0 (A3):** create categories/items, project returned assignment points, calculate derived views, and expose history separately from the current `GradeEntry` projection.
+4. **Quiz engine (A4):** attach quiz resources through the existing typed course-item and grade-item seams.
+5. **Course copy (A7):** clone copyable records, preserve `copied_from_id`, remap typed sources/resources, and emit an activity event describing the mapping.
+
+## Non-goals
+
+This foundation does not provide CRUD endpoints, UI, permissions, quiz questions, grade calculations, completion evaluation, notification delivery, SIS synchronization, course-copy execution, automatic activity logging, or historical grade revisions. Each feature PR must add its behavior and authorization without weakening these storage invariants.
+
+The migration is explicit and supports both SQLite and PostgreSQL. JSON documents use JSON on SQLite and JSONB on PostgreSQL; cross-scope protections use portable composite foreign keys rather than database-specific application assumptions.

--- a/src/fair_platform/backend/alembic/versions/20260812_0029_lms_primitives.py
+++ b/src/fair_platform/backend/alembic/versions/20260812_0029_lms_primitives.py
@@ -1,0 +1,899 @@
+"""Add normalized LMS foundation primitives.
+
+Revision ID: 20260812_0029
+Revises: 20260727_0028
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "20260812_0029"
+down_revision: str = "20260727_0028"
+branch_labels = None
+depends_on = None
+
+
+def _json_document() -> sa.JSON:
+    return sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def _create_activity_event_guards() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute(
+            sa.text(
+                """
+                CREATE FUNCTION fair_reject_activity_event_mutation()
+                RETURNS trigger AS $$ BEGIN
+                  RAISE EXCEPTION 'ActivityEvent % is append-only', OLD.id;
+                END; $$ LANGUAGE plpgsql;
+                """
+            )
+        )
+        op.execute(
+            sa.text(
+                """
+                CREATE TRIGGER fair_activity_event_append_only
+                BEFORE UPDATE OR DELETE ON activity_events
+                FOR EACH ROW EXECUTE FUNCTION fair_reject_activity_event_mutation()
+                """
+            )
+        )
+    else:
+        op.execute(
+            sa.text(
+                "CREATE TRIGGER fair_activity_event_append_only_update "
+                "BEFORE UPDATE ON activity_events BEGIN SELECT RAISE(ABORT, "
+                "'ActivityEvent is append-only'); END"
+            )
+        )
+        op.execute(
+            sa.text(
+                "CREATE TRIGGER fair_activity_event_append_only_delete "
+                "BEFORE DELETE ON activity_events BEGIN SELECT RAISE(ABORT, "
+                "'ActivityEvent is append-only'); END"
+            )
+        )
+
+
+def _drop_activity_event_guards() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute(
+            sa.text("DROP TRIGGER fair_activity_event_append_only ON activity_events")
+        )
+        op.execute(sa.text("DROP FUNCTION fair_reject_activity_event_mutation()"))
+    else:
+        op.execute(sa.text("DROP TRIGGER fair_activity_event_append_only_delete"))
+        op.execute(sa.text("DROP TRIGGER fair_activity_event_append_only_update"))
+
+
+def upgrade() -> None:
+    op.create_table(
+        "organizations",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("slug", sa.String(length=128), nullable=False),
+        sa.Column("attributes", _json_document(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug"),
+    )
+
+    with op.batch_alter_table("courses") as batch_op:
+        batch_op.add_column(sa.Column("organization_id", sa.UUID(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_courses_organization_id_organizations",
+            "organizations",
+            ["organization_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+        batch_op.create_unique_constraint(
+            "uq_courses_id_organization", ["id", "organization_id"]
+        )
+
+    op.create_table(
+        "organization_memberships",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("role", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("joined_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "role IN ('owner', 'admin', 'member')",
+            name="ck_organization_memberships_role",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'inactive')",
+            name="ck_organization_memberships_status",
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "organization_id",
+            "user_id",
+            name="uq_organization_memberships_organization_user",
+        ),
+    )
+    op.create_index(
+        "ix_organization_memberships_user_status",
+        "organization_memberships",
+        ["user_id", "status"],
+    )
+
+    op.create_table(
+        "cohorts",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "organization_id", "name", name="uq_cohorts_organization_name"
+        ),
+        sa.UniqueConstraint("id", "organization_id", name="uq_cohorts_id_organization"),
+    )
+
+    op.create_table(
+        "course_sections",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("course_id", sa.UUID(), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("visibility", sa.String(length=32), nullable=False),
+        sa.Column("copied_from_id", sa.UUID(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "position >= 0", name="ck_course_sections_position_non_negative"
+        ),
+        sa.CheckConstraint(
+            "visibility IN ('draft', 'published', 'hidden')",
+            name="ck_course_sections_visibility",
+        ),
+        sa.ForeignKeyConstraint(
+            ["copied_from_id"], ["course_sections.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "course_id", "position", name="uq_course_sections_course_position"
+        ),
+        sa.UniqueConstraint("id", "course_id", name="uq_course_sections_id_course"),
+    )
+    op.create_index(
+        "ix_course_sections_course_visibility",
+        "course_sections",
+        ["course_id", "visibility"],
+    )
+
+    op.create_table(
+        "course_items",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("course_id", sa.UUID(), nullable=False),
+        sa.Column("section_id", sa.UUID(), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("kind", sa.String(length=64), nullable=False),
+        sa.Column("visibility", sa.String(length=32), nullable=False),
+        sa.Column("resource_type", sa.String(length=64), nullable=True),
+        sa.Column("resource_id", sa.UUID(), nullable=True),
+        sa.Column("copied_from_id", sa.UUID(), nullable=True),
+        sa.Column("payload_schema_uri", sa.String(length=2048), nullable=True),
+        sa.Column("payload", _json_document(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "position >= 0", name="ck_course_items_position_non_negative"
+        ),
+        sa.CheckConstraint(
+            "(resource_type IS NULL AND resource_id IS NULL) OR "
+            "(resource_type IS NOT NULL AND resource_id IS NOT NULL)",
+            name="ck_course_items_resource_pair",
+        ),
+        sa.CheckConstraint(
+            "visibility IN ('draft', 'published', 'hidden')",
+            name="ck_course_items_visibility",
+        ),
+        sa.ForeignKeyConstraint(
+            ["copied_from_id"], ["course_items.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(
+            ["section_id", "course_id"],
+            ["course_sections.id", "course_sections.course_id"],
+            name="fk_course_items_section_course",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "section_id", "position", name="uq_course_items_section_position"
+        ),
+        sa.UniqueConstraint("id", "course_id", name="uq_course_items_id_course"),
+        sa.UniqueConstraint(
+            "course_id",
+            "resource_type",
+            "resource_id",
+            name="uq_course_items_course_resource",
+        ),
+    )
+    op.create_index(
+        "ix_course_items_course_kind", "course_items", ["course_id", "kind"]
+    )
+    op.create_index(
+        "ix_course_items_resource",
+        "course_items",
+        ["resource_type", "resource_id"],
+    )
+
+    op.create_table(
+        "completion_rules",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("course_id", sa.UUID(), nullable=False),
+        sa.Column("course_item_id", sa.UUID(), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("rule_type", sa.String(length=64), nullable=False),
+        sa.Column("config", _json_document(), nullable=False),
+        sa.Column("is_required", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "position >= 0", name="ck_completion_rules_position_non_negative"
+        ),
+        sa.ForeignKeyConstraint(
+            ["course_item_id", "course_id"],
+            ["course_items.id", "course_items.course_id"],
+            name="fk_completion_rules_item_course",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "course_item_id", "position", name="uq_completion_rules_item_position"
+        ),
+    )
+    op.create_index(
+        "ix_completion_rules_course_type",
+        "completion_rules",
+        ["course_id", "rule_type"],
+    )
+
+    op.create_table(
+        "availability_rules",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("course_id", sa.UUID(), nullable=False),
+        sa.Column("course_item_id", sa.UUID(), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("rule_type", sa.String(length=64), nullable=False),
+        sa.Column("config", _json_document(), nullable=False),
+        sa.Column("is_enabled", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "position >= 0", name="ck_availability_rules_position_non_negative"
+        ),
+        sa.ForeignKeyConstraint(
+            ["course_item_id", "course_id"],
+            ["course_items.id", "course_items.course_id"],
+            name="fk_availability_rules_item_course",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "course_item_id", "position", name="uq_availability_rules_item_position"
+        ),
+    )
+    op.create_index(
+        "ix_availability_rules_course_type",
+        "availability_rules",
+        ["course_id", "rule_type"],
+    )
+
+    op.create_table(
+        "user_item_completions",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("course_id", sa.UUID(), nullable=False),
+        sa.Column("course_item_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("source_type", sa.String(length=64), nullable=True),
+        sa.Column("source_id", sa.UUID(), nullable=True),
+        sa.Column("evidence", _json_document(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "(source_type IS NULL AND source_id IS NULL) OR "
+            "(source_type IS NOT NULL AND source_id IS NOT NULL)",
+            name="ck_user_item_completions_source_pair",
+        ),
+        sa.CheckConstraint(
+            "(status = 'completed' AND completed_at IS NOT NULL) OR "
+            "(status != 'completed' AND completed_at IS NULL)",
+            name="ck_user_item_completions_timestamp",
+        ),
+        sa.CheckConstraint(
+            "status IN ('not_started', 'in_progress', 'completed')",
+            name="ck_user_item_completions_status",
+        ),
+        sa.ForeignKeyConstraint(
+            ["course_item_id", "course_id"],
+            ["course_items.id", "course_items.course_id"],
+            name="fk_user_item_completions_item_course",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id", "course_id"],
+            ["enrollments.user_id", "enrollments.course_id"],
+            name="fk_user_item_completions_enrollment",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "course_item_id",
+            "user_id",
+            name="uq_user_item_completions_item_user",
+        ),
+    )
+    op.create_index(
+        "ix_user_item_completions_course_status",
+        "user_item_completions",
+        ["course_id", "status"],
+    )
+    op.create_index(
+        "ix_user_item_completions_course_user",
+        "user_item_completions",
+        ["course_id", "user_id"],
+    )
+
+    op.create_table(
+        "grade_categories",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("course_id", sa.UUID(), nullable=False),
+        sa.Column("parent_category_id", sa.UUID(), nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("aggregation_strategy", sa.String(length=32), nullable=False),
+        sa.Column("weight", sa.Numeric(precision=12, scale=6), nullable=True),
+        sa.Column("calculation_policy", _json_document(), nullable=False),
+        sa.Column("copied_from_id", sa.UUID(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "aggregation_strategy IN "
+            "('sum', 'weighted_mean', 'simple_mean', 'highest')",
+            name="ck_grade_categories_aggregation_strategy",
+        ),
+        sa.CheckConstraint(
+            "position >= 0", name="ck_grade_categories_position_non_negative"
+        ),
+        sa.CheckConstraint(
+            "weight IS NULL OR weight >= 0", name="ck_grade_categories_weight"
+        ),
+        sa.ForeignKeyConstraint(
+            ["copied_from_id"], ["grade_categories.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["parent_category_id", "course_id"],
+            ["grade_categories.id", "grade_categories.course_id"],
+            name="fk_grade_categories_parent_course",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "course_id", "position", name="uq_grade_categories_course_position"
+        ),
+        sa.UniqueConstraint("id", "course_id", name="uq_grade_categories_id_course"),
+    )
+    op.create_index(
+        "ix_grade_categories_course_parent",
+        "grade_categories",
+        ["course_id", "parent_category_id"],
+    )
+
+    op.create_table(
+        "grade_items",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("course_id", sa.UUID(), nullable=False),
+        sa.Column("category_id", sa.UUID(), nullable=True),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("max_points", sa.Numeric(precision=12, scale=4), nullable=False),
+        sa.Column("weight", sa.Numeric(precision=12, scale=6), nullable=True),
+        sa.Column("calculation_policy", _json_document(), nullable=False),
+        sa.Column("release_policy", _json_document(), nullable=False),
+        sa.Column("source_type", sa.String(length=64), nullable=True),
+        sa.Column("source_id", sa.UUID(), nullable=True),
+        sa.Column("copied_from_id", sa.UUID(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("max_points > 0", name="ck_grade_items_max_points_positive"),
+        sa.CheckConstraint(
+            "position >= 0", name="ck_grade_items_position_non_negative"
+        ),
+        sa.CheckConstraint(
+            "(source_type IS NULL AND source_id IS NULL) OR "
+            "(source_type IS NOT NULL AND source_id IS NOT NULL)",
+            name="ck_grade_items_source_pair",
+        ),
+        sa.CheckConstraint(
+            "weight IS NULL OR weight >= 0", name="ck_grade_items_weight"
+        ),
+        sa.ForeignKeyConstraint(
+            ["category_id", "course_id"],
+            ["grade_categories.id", "grade_categories.course_id"],
+            name="fk_grade_items_category_course",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["copied_from_id"], ["grade_items.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "course_id", "position", name="uq_grade_items_course_position"
+        ),
+        sa.UniqueConstraint("id", "course_id", name="uq_grade_items_id_course"),
+        sa.UniqueConstraint(
+            "course_id",
+            "source_type",
+            "source_id",
+            name="uq_grade_items_course_source",
+        ),
+    )
+    op.create_index(
+        "ix_grade_items_course_category",
+        "grade_items",
+        ["course_id", "category_id"],
+    )
+    op.create_index(
+        "ix_grade_items_source", "grade_items", ["source_type", "source_id"]
+    )
+
+    op.create_table(
+        "grade_entries",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("course_id", sa.UUID(), nullable=False),
+        sa.Column("grade_item_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("points_earned", sa.Numeric(precision=12, scale=4), nullable=True),
+        sa.Column("release_state", sa.String(length=32), nullable=False),
+        sa.Column("released_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("graded_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("source_type", sa.String(length=64), nullable=True),
+        sa.Column("source_id", sa.UUID(), nullable=True),
+        sa.Column("source_version", sa.String(length=128), nullable=True),
+        sa.Column("recorded_by_user_id", sa.UUID(), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "points_earned IS NULL OR points_earned >= 0",
+            name="ck_grade_entries_points_non_negative",
+        ),
+        sa.CheckConstraint(
+            "release_state IN ('unreleased', 'released')",
+            name="ck_grade_entries_release_state",
+        ),
+        sa.CheckConstraint(
+            "(release_state = 'unreleased' AND released_at IS NULL) OR "
+            "(release_state = 'released' AND released_at IS NOT NULL)",
+            name="ck_grade_entries_release_timestamp",
+        ),
+        sa.CheckConstraint(
+            "(source_type IS NULL AND source_id IS NULL) OR "
+            "(source_type IS NOT NULL AND source_id IS NOT NULL)",
+            name="ck_grade_entries_source_pair",
+        ),
+        sa.CheckConstraint(
+            "(status = 'graded' AND points_earned IS NOT NULL) OR "
+            "(status IN ('missing', 'excused') AND points_earned IS NULL)",
+            name="ck_grade_entries_status_points",
+        ),
+        sa.ForeignKeyConstraint(
+            ["grade_item_id", "course_id"],
+            ["grade_items.id", "grade_items.course_id"],
+            name="fk_grade_entries_item_course",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["recorded_by_user_id"], ["users.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id", "course_id"],
+            ["enrollments.user_id", "enrollments.course_id"],
+            name="fk_grade_entries_enrollment",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "grade_item_id", "user_id", name="uq_grade_entries_item_user"
+        ),
+    )
+    op.create_index(
+        "ix_grade_entries_course_user",
+        "grade_entries",
+        ["course_id", "user_id"],
+    )
+    op.create_index(
+        "ix_grade_entries_release",
+        "grade_entries",
+        ["course_id", "release_state"],
+    )
+    op.create_index(
+        "ix_grade_entries_source", "grade_entries", ["source_type", "source_id"]
+    )
+
+    op.create_table(
+        "course_groups",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("course_id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("course_id", "name", name="uq_course_groups_course_name"),
+        sa.UniqueConstraint("id", "course_id", name="uq_course_groups_id_course"),
+    )
+
+    op.create_table(
+        "course_group_memberships",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("course_id", sa.UUID(), nullable=False),
+        sa.Column("group_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("role", sa.String(length=32), nullable=False),
+        sa.Column("joined_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "role IN ('member', 'leader')",
+            name="ck_course_group_memberships_role",
+        ),
+        sa.ForeignKeyConstraint(
+            ["group_id", "course_id"],
+            ["course_groups.id", "course_groups.course_id"],
+            name="fk_course_group_memberships_group_course",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id", "course_id"],
+            ["enrollments.user_id", "enrollments.course_id"],
+            name="fk_course_group_memberships_enrollment",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "group_id", "user_id", name="uq_course_group_memberships_group_user"
+        ),
+    )
+    op.create_index(
+        "ix_course_group_memberships_course_user",
+        "course_group_memberships",
+        ["course_id", "user_id"],
+    )
+
+    op.create_table(
+        "cohort_memberships",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.Column("cohort_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("joined_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('active', 'inactive')",
+            name="ck_cohort_memberships_status",
+        ),
+        sa.ForeignKeyConstraint(
+            ["cohort_id", "organization_id"],
+            ["cohorts.id", "cohorts.organization_id"],
+            name="fk_cohort_memberships_cohort_organization",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id", "user_id"],
+            [
+                "organization_memberships.organization_id",
+                "organization_memberships.user_id",
+            ],
+            name="fk_cohort_memberships_organization_user",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "cohort_id", "user_id", name="uq_cohort_memberships_cohort_user"
+        ),
+    )
+    op.create_index(
+        "ix_cohort_memberships_user_status",
+        "cohort_memberships",
+        ["user_id", "status"],
+    )
+
+    op.create_table(
+        "external_identifiers",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.Column("system", sa.String(length=128), nullable=False),
+        sa.Column("subject_type", sa.String(length=32), nullable=False),
+        sa.Column("external_id", sa.String(length=255), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=True),
+        sa.Column("course_id", sa.UUID(), nullable=True),
+        sa.Column("cohort_id", sa.UUID(), nullable=True),
+        sa.Column("attributes", _json_document(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "(subject_type = 'user' AND user_id IS NOT NULL "
+            "AND course_id IS NULL AND cohort_id IS NULL) OR "
+            "(subject_type = 'course' AND course_id IS NOT NULL "
+            "AND user_id IS NULL AND cohort_id IS NULL) OR "
+            "(subject_type = 'cohort' AND cohort_id IS NOT NULL "
+            "AND user_id IS NULL AND course_id IS NULL)",
+            name="ck_external_identifiers_subject",
+        ),
+        sa.ForeignKeyConstraint(
+            ["cohort_id", "organization_id"],
+            ["cohorts.id", "cohorts.organization_id"],
+            name="fk_external_identifiers_cohort_organization",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["course_id", "organization_id"],
+            ["courses.id", "courses.organization_id"],
+            name="fk_external_identifiers_course_organization",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id", "user_id"],
+            [
+                "organization_memberships.organization_id",
+                "organization_memberships.user_id",
+            ],
+            name="fk_external_identifiers_organization_user",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "organization_id",
+            "system",
+            "cohort_id",
+            name="uq_external_identifiers_cohort",
+        ),
+        sa.UniqueConstraint(
+            "organization_id",
+            "system",
+            "course_id",
+            name="uq_external_identifiers_course",
+        ),
+        sa.UniqueConstraint(
+            "organization_id",
+            "system",
+            "subject_type",
+            "external_id",
+            name="uq_external_identifiers_external",
+        ),
+        sa.UniqueConstraint(
+            "organization_id",
+            "system",
+            "user_id",
+            name="uq_external_identifiers_user",
+        ),
+    )
+    op.create_index(
+        "ix_external_identifiers_lookup",
+        "external_identifiers",
+        ["system", "external_id"],
+    )
+
+    op.create_table(
+        "calendar_events",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("course_id", sa.UUID(), nullable=True),
+        sa.Column("owner_user_id", sa.UUID(), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("starts_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ends_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("all_day", sa.Boolean(), nullable=False),
+        sa.Column("timezone_name", sa.String(length=128), nullable=True),
+        sa.Column("visibility", sa.String(length=32), nullable=False),
+        sa.Column("source_type", sa.String(length=64), nullable=True),
+        sa.Column("source_id", sa.UUID(), nullable=True),
+        sa.Column("copied_from_id", sa.UUID(), nullable=True),
+        sa.Column("recurrence", _json_document(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "visibility != 'course' OR course_id IS NOT NULL",
+            name="ck_calendar_events_course_visibility_scope",
+        ),
+        sa.CheckConstraint(
+            "(source_type IS NULL AND source_id IS NULL) OR "
+            "(source_type IS NOT NULL AND source_id IS NOT NULL)",
+            name="ck_calendar_events_source_pair",
+        ),
+        sa.CheckConstraint(
+            "ends_at IS NULL OR ends_at > starts_at",
+            name="ck_calendar_events_time_order",
+        ),
+        sa.CheckConstraint(
+            "visibility IN ('private', 'course')",
+            name="ck_calendar_events_visibility",
+        ),
+        sa.ForeignKeyConstraint(
+            ["copied_from_id"], ["calendar_events.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["owner_user_id"], ["users.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_calendar_events_course_start",
+        "calendar_events",
+        ["course_id", "starts_at"],
+    )
+    op.create_index(
+        "ix_calendar_events_owner_start",
+        "calendar_events",
+        ["owner_user_id", "starts_at"],
+    )
+    op.create_index(
+        "ix_calendar_events_source",
+        "calendar_events",
+        ["source_type", "source_id"],
+    )
+
+    op.create_table(
+        "notification_preferences",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("channel", sa.String(length=32), nullable=False),
+        sa.Column("event_type", sa.String(length=128), nullable=False),
+        sa.Column("delivery_mode", sa.String(length=32), nullable=False),
+        sa.Column("source_type", sa.String(length=64), nullable=True),
+        sa.Column("source_id", sa.UUID(), nullable=True),
+        sa.Column("config", _json_document(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "channel IN ('web', 'email', 'push')",
+            name="ck_notification_preferences_channel",
+        ),
+        sa.CheckConstraint(
+            "delivery_mode IN ('immediate', 'digest', 'off')",
+            name="ck_notification_preferences_delivery_mode",
+        ),
+        sa.CheckConstraint(
+            "(source_type IS NULL AND source_id IS NULL) OR "
+            "(source_type IS NOT NULL AND source_id IS NOT NULL)",
+            name="ck_notification_preferences_source_pair",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "channel",
+            "event_type",
+            name="uq_notification_preferences_user_channel_event",
+        ),
+    )
+    op.create_index(
+        "ix_notification_preferences_source",
+        "notification_preferences",
+        ["source_type", "source_id"],
+    )
+    op.create_index(
+        "ix_notification_preferences_user_mode",
+        "notification_preferences",
+        ["user_id", "delivery_mode"],
+    )
+
+    op.create_table(
+        "activity_events",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("event_type", sa.String(length=128), nullable=False),
+        sa.Column("schema_uri", sa.String(length=2048), nullable=True),
+        sa.Column("actor_user_id", sa.UUID(), nullable=True),
+        sa.Column("course_id", sa.UUID(), nullable=True),
+        sa.Column("organization_id", sa.UUID(), nullable=True),
+        sa.Column("object_type", sa.String(length=64), nullable=True),
+        sa.Column("object_id", sa.UUID(), nullable=True),
+        sa.Column("source_type", sa.String(length=64), nullable=True),
+        sa.Column("source_id", sa.UUID(), nullable=True),
+        sa.Column("payload", _json_document(), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("recorded_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "(object_type IS NULL AND object_id IS NULL) OR "
+            "(object_type IS NOT NULL AND object_id IS NOT NULL)",
+            name="ck_activity_events_object_pair",
+        ),
+        sa.CheckConstraint(
+            "(source_type IS NULL AND source_id IS NULL) OR "
+            "(source_type IS NOT NULL AND source_id IS NOT NULL)",
+            name="ck_activity_events_source_pair",
+        ),
+        sa.ForeignKeyConstraint(["actor_user_id"], ["users.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="RESTRICT"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_activity_events_actor_occurred",
+        "activity_events",
+        ["actor_user_id", "occurred_at"],
+    )
+    op.create_index(
+        "ix_activity_events_course_occurred",
+        "activity_events",
+        ["course_id", "occurred_at"],
+    )
+    op.create_index(
+        "ix_activity_events_object",
+        "activity_events",
+        ["object_type", "object_id"],
+    )
+    op.create_index(
+        "ix_activity_events_organization_occurred",
+        "activity_events",
+        ["organization_id", "occurred_at"],
+    )
+    op.create_index(
+        "ix_activity_events_source",
+        "activity_events",
+        ["source_type", "source_id"],
+    )
+    _create_activity_event_guards()
+
+
+def downgrade() -> None:
+    _drop_activity_event_guards()
+    op.drop_table("activity_events")
+    op.drop_table("notification_preferences")
+    op.drop_table("calendar_events")
+    op.drop_table("external_identifiers")
+    op.drop_table("cohort_memberships")
+    op.drop_table("course_group_memberships")
+    op.drop_table("course_groups")
+    op.drop_table("grade_entries")
+    op.drop_table("grade_items")
+    op.drop_table("grade_categories")
+    op.drop_table("user_item_completions")
+    op.drop_table("availability_rules")
+    op.drop_table("completion_rules")
+    op.drop_table("course_items")
+    op.drop_table("course_sections")
+    op.drop_table("cohorts")
+    op.drop_table("organization_memberships")
+    with op.batch_alter_table("courses") as batch_op:
+        batch_op.drop_constraint("uq_courses_id_organization", type_="unique")
+        batch_op.drop_constraint(
+            "fk_courses_organization_id_organizations", type_="foreignkey"
+        )
+        batch_op.drop_column("organization_id")
+    op.drop_table("organizations")

--- a/src/fair_platform/backend/data/models/__init__.py
+++ b/src/fair_platform/backend/data/models/__init__.py
@@ -65,6 +65,42 @@ from .lms_communication import (
     Notification,
     SubmissionComment,
 )
+from .lms_content import CourseContentVisibility, CourseItem, CourseSection
+from .lms_events import (
+    ActivityEvent,
+    CalendarEvent,
+    CalendarEventVisibility,
+    NotificationChannel,
+    NotificationDeliveryMode,
+    NotificationPreference,
+)
+from .lms_gradebook import (
+    GradeAggregationStrategy,
+    GradeCategory,
+    GradeEntry,
+    GradeEntryStatus,
+    GradeItem,
+    GradeReleaseState,
+)
+from .lms_organization import (
+    Cohort,
+    CohortMembership,
+    CourseGroup,
+    CourseGroupMembership,
+    CourseGroupMembershipRole,
+    ExternalIdentifier,
+    ExternalIdentifierSubjectType,
+    MembershipStatus,
+    Organization,
+    OrganizationMembership,
+    OrganizationMembershipRole,
+)
+from .lms_progress import (
+    AvailabilityRule,
+    CompletionRule,
+    ItemCompletionStatus,
+    UserItemCompletion,
+)
 
 __all__ = [
     "User",
@@ -132,4 +168,34 @@ __all__ = [
     "CoursePostKind",
     "Notification",
     "SubmissionComment",
+    "ActivityEvent",
+    "AvailabilityRule",
+    "CalendarEvent",
+    "CalendarEventVisibility",
+    "Cohort",
+    "CohortMembership",
+    "CompletionRule",
+    "CourseContentVisibility",
+    "CourseGroup",
+    "CourseGroupMembership",
+    "CourseGroupMembershipRole",
+    "CourseItem",
+    "CourseSection",
+    "ExternalIdentifier",
+    "ExternalIdentifierSubjectType",
+    "GradeAggregationStrategy",
+    "GradeCategory",
+    "GradeEntry",
+    "GradeEntryStatus",
+    "GradeItem",
+    "GradeReleaseState",
+    "ItemCompletionStatus",
+    "MembershipStatus",
+    "NotificationChannel",
+    "NotificationDeliveryMode",
+    "NotificationPreference",
+    "Organization",
+    "OrganizationMembership",
+    "OrganizationMembershipRole",
+    "UserItemCompletion",
 ]

--- a/src/fair_platform/backend/data/models/course.py
+++ b/src/fair_platform/backend/data/models/course.py
@@ -1,6 +1,16 @@
 from datetime import datetime
 from uuid import UUID
-from sqlalchemy import String, Text, ForeignKey, UUID as _UUID, Boolean, TIMESTAMP, true, false
+from sqlalchemy import (
+    Boolean,
+    ForeignKey,
+    String,
+    Text,
+    TIMESTAMP,
+    UUID as _UUID,
+    UniqueConstraint,
+    false,
+    true,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import Optional, List, TYPE_CHECKING
 
@@ -13,16 +23,28 @@ if TYPE_CHECKING:
     from .flow import Flow
     from .artifact import Artifact
     from .execution import Execution
+    from .lms_content import CourseSection
+    from .lms_events import ActivityEvent, CalendarEvent
+    from .lms_gradebook import GradeCategory, GradeItem
+    from .lms_organization import CourseGroup, Organization
 
 
 class Course(Base):
     __tablename__ = "courses"
+    __table_args__ = (
+        UniqueConstraint("id", "organization_id", name="uq_courses_id_organization"),
+    )
 
     id: Mapped[UUID] = mapped_column(_UUID, primary_key=True)
     name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     instructor_id: Mapped[UUID] = mapped_column(
         _UUID, ForeignKey("users.id"), nullable=False
+    )
+    organization_id: Mapped[Optional[UUID]] = mapped_column(
+        _UUID,
+        ForeignKey("organizations.id", ondelete="SET NULL"),
+        nullable=True,
     )
     enrollment_code: Mapped[Optional[str]] = mapped_column(
         String(32), unique=True, nullable=True
@@ -55,6 +77,36 @@ class Course(Base):
     )
     executions: Mapped[List["Execution"]] = relationship(
         "Execution", back_populates="course"
+    )
+    organization: Mapped[Optional["Organization"]] = relationship(
+        "Organization", back_populates="courses"
+    )
+    sections: Mapped[List["CourseSection"]] = relationship(
+        "CourseSection",
+        back_populates="course",
+        cascade="all, delete-orphan",
+        order_by="CourseSection.position",
+    )
+    grade_categories: Mapped[List["GradeCategory"]] = relationship(
+        "GradeCategory",
+        back_populates="course",
+        cascade="all, delete-orphan",
+        order_by="GradeCategory.position",
+    )
+    grade_items: Mapped[List["GradeItem"]] = relationship(
+        "GradeItem",
+        back_populates="course",
+        cascade="all, delete-orphan",
+        order_by="GradeItem.position",
+    )
+    groups: Mapped[List["CourseGroup"]] = relationship(
+        "CourseGroup", back_populates="course", cascade="all, delete-orphan"
+    )
+    calendar_events: Mapped[List["CalendarEvent"]] = relationship(
+        "CalendarEvent", back_populates="course", cascade="all, delete-orphan"
+    )
+    activity_events: Mapped[List["ActivityEvent"]] = relationship(
+        "ActivityEvent", back_populates="course"
     )
 
     def __repr__(self) -> str:

--- a/src/fair_platform/backend/data/models/lms_content.py
+++ b/src/fair_platform/backend/data/models/lms_content.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    String,
+    Text,
+    UUID as SAUUID,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..database import Base
+from .types import json_document_type
+
+if TYPE_CHECKING:
+    from .course import Course
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class CourseContentVisibility(str, Enum):
+    draft = "draft"
+    published = "published"
+    hidden = "hidden"
+
+
+class CourseSection(Base):
+    """An ordered, presentational container within one course."""
+
+    __tablename__ = "course_sections"
+    __table_args__ = (
+        UniqueConstraint(
+            "course_id", "position", name="uq_course_sections_course_position"
+        ),
+        UniqueConstraint("id", "course_id", name="uq_course_sections_id_course"),
+        CheckConstraint(
+            "position >= 0", name="ck_course_sections_position_non_negative"
+        ),
+        CheckConstraint(
+            "visibility IN ('draft', 'published', 'hidden')",
+            name="ck_course_sections_visibility",
+        ),
+        Index("ix_course_sections_course_visibility", "course_id", "visibility"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    course_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("courses.id", ondelete="CASCADE"), nullable=False
+    )
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    summary: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    visibility: Mapped[CourseContentVisibility] = mapped_column(
+        String(32), nullable=False, default=CourseContentVisibility.draft
+    )
+    copied_from_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("course_sections.id", ondelete="RESTRICT"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    course: Mapped["Course"] = relationship("Course", back_populates="sections")
+    items: Mapped[list["CourseItem"]] = relationship(
+        "CourseItem",
+        back_populates="section",
+        cascade="all, delete-orphan",
+        order_by="CourseItem.position",
+    )
+    copied_from: Mapped[Optional["CourseSection"]] = relationship(
+        "CourseSection", remote_side=[id], foreign_keys=[copied_from_id]
+    )
+
+
+class CourseItem(Base):
+    """An ordered course item with an extensible, typed resource link."""
+
+    __tablename__ = "course_items"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["section_id", "course_id"],
+            ["course_sections.id", "course_sections.course_id"],
+            name="fk_course_items_section_course",
+            ondelete="CASCADE",
+        ),
+        UniqueConstraint(
+            "section_id", "position", name="uq_course_items_section_position"
+        ),
+        UniqueConstraint("id", "course_id", name="uq_course_items_id_course"),
+        UniqueConstraint(
+            "course_id",
+            "resource_type",
+            "resource_id",
+            name="uq_course_items_course_resource",
+        ),
+        CheckConstraint("position >= 0", name="ck_course_items_position_non_negative"),
+        CheckConstraint(
+            "visibility IN ('draft', 'published', 'hidden')",
+            name="ck_course_items_visibility",
+        ),
+        CheckConstraint(
+            "(resource_type IS NULL AND resource_id IS NULL) OR "
+            "(resource_type IS NOT NULL AND resource_id IS NOT NULL)",
+            name="ck_course_items_resource_pair",
+        ),
+        Index("ix_course_items_course_kind", "course_id", "kind"),
+        Index("ix_course_items_resource", "resource_type", "resource_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    course_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    section_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    kind: Mapped[str] = mapped_column(String(64), nullable=False)
+    visibility: Mapped[CourseContentVisibility] = mapped_column(
+        String(32), nullable=False, default=CourseContentVisibility.draft
+    )
+    resource_type: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    resource_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    copied_from_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("course_items.id", ondelete="RESTRICT"), nullable=True
+    )
+    payload_schema_uri: Mapped[Optional[str]] = mapped_column(
+        String(2048), nullable=True
+    )
+    payload: Mapped[dict[str, Any]] = mapped_column(
+        json_document_type(), nullable=False, default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    section: Mapped[CourseSection] = relationship(
+        "CourseSection", back_populates="items"
+    )
+    copied_from: Mapped[Optional["CourseItem"]] = relationship(
+        "CourseItem", remote_side=[id], foreign_keys=[copied_from_id]
+    )
+
+
+__all__ = ["CourseContentVisibility", "CourseItem", "CourseSection"]

--- a/src/fair_platform/backend/data/models/lms_events.py
+++ b/src/fair_platform/backend/data/models/lms_events.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UUID as SAUUID,
+    UniqueConstraint,
+    event,
+)
+from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
+
+from ..database import Base
+from .types import json_document_type
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class CalendarEventVisibility(str, Enum):
+    private = "private"
+    course = "course"
+
+
+class NotificationChannel(str, Enum):
+    web = "web"
+    email = "email"
+    push = "push"
+
+
+class NotificationDeliveryMode(str, Enum):
+    immediate = "immediate"
+    digest = "digest"
+    off = "off"
+
+
+class CalendarEvent(Base):
+    __tablename__ = "calendar_events"
+    __table_args__ = (
+        CheckConstraint(
+            "ends_at IS NULL OR ends_at > starts_at",
+            name="ck_calendar_events_time_order",
+        ),
+        CheckConstraint(
+            "visibility IN ('private', 'course')",
+            name="ck_calendar_events_visibility",
+        ),
+        CheckConstraint(
+            "visibility != 'course' OR course_id IS NOT NULL",
+            name="ck_calendar_events_course_visibility_scope",
+        ),
+        CheckConstraint(
+            "(source_type IS NULL AND source_id IS NULL) OR "
+            "(source_type IS NOT NULL AND source_id IS NOT NULL)",
+            name="ck_calendar_events_source_pair",
+        ),
+        Index("ix_calendar_events_course_start", "course_id", "starts_at"),
+        Index("ix_calendar_events_owner_start", "owner_user_id", "starts_at"),
+        Index("ix_calendar_events_source", "source_type", "source_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    course_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("courses.id", ondelete="CASCADE"), nullable=True
+    )
+    owner_user_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+    )
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    starts_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    ends_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    all_day: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    timezone_name: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    visibility: Mapped[CalendarEventVisibility] = mapped_column(
+        String(32), nullable=False, default=CalendarEventVisibility.private
+    )
+    source_type: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    source_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    copied_from_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("calendar_events.id", ondelete="RESTRICT"), nullable=True
+    )
+    recurrence: Mapped[dict[str, Any]] = mapped_column(
+        json_document_type(), nullable=False, default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    course = relationship("Course", back_populates="calendar_events")
+    owner = relationship("User", foreign_keys=[owner_user_id])
+    copied_from: Mapped[Optional["CalendarEvent"]] = relationship(
+        "CalendarEvent", remote_side=[id], foreign_keys=[copied_from_id]
+    )
+
+
+class NotificationPreference(Base):
+    __tablename__ = "notification_preferences"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "channel",
+            "event_type",
+            name="uq_notification_preferences_user_channel_event",
+        ),
+        CheckConstraint(
+            "channel IN ('web', 'email', 'push')",
+            name="ck_notification_preferences_channel",
+        ),
+        CheckConstraint(
+            "delivery_mode IN ('immediate', 'digest', 'off')",
+            name="ck_notification_preferences_delivery_mode",
+        ),
+        CheckConstraint(
+            "(source_type IS NULL AND source_id IS NULL) OR "
+            "(source_type IS NOT NULL AND source_id IS NOT NULL)",
+            name="ck_notification_preferences_source_pair",
+        ),
+        Index("ix_notification_preferences_user_mode", "user_id", "delivery_mode"),
+        Index("ix_notification_preferences_source", "source_type", "source_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    user_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    channel: Mapped[NotificationChannel] = mapped_column(String(32), nullable=False)
+    event_type: Mapped[str] = mapped_column(String(128), nullable=False, default="*")
+    delivery_mode: Mapped[NotificationDeliveryMode] = mapped_column(
+        String(32), nullable=False, default=NotificationDeliveryMode.immediate
+    )
+    source_type: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    source_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    config: Mapped[dict[str, Any]] = mapped_column(
+        json_document_type(), nullable=False, default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    user = relationship("User")
+
+
+class ActivityEvent(Base):
+    """An immutable audit/event fact for LMS projections and integrations."""
+
+    __tablename__ = "activity_events"
+    __table_args__ = (
+        CheckConstraint(
+            "(object_type IS NULL AND object_id IS NULL) OR "
+            "(object_type IS NOT NULL AND object_id IS NOT NULL)",
+            name="ck_activity_events_object_pair",
+        ),
+        CheckConstraint(
+            "(source_type IS NULL AND source_id IS NULL) OR "
+            "(source_type IS NOT NULL AND source_id IS NOT NULL)",
+            name="ck_activity_events_source_pair",
+        ),
+        Index("ix_activity_events_course_occurred", "course_id", "occurred_at"),
+        Index(
+            "ix_activity_events_organization_occurred",
+            "organization_id",
+            "occurred_at",
+        ),
+        Index("ix_activity_events_actor_occurred", "actor_user_id", "occurred_at"),
+        Index("ix_activity_events_object", "object_type", "object_id"),
+        Index("ix_activity_events_source", "source_type", "source_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    event_type: Mapped[str] = mapped_column(String(128), nullable=False)
+    schema_uri: Mapped[Optional[str]] = mapped_column(String(2048), nullable=True)
+    actor_user_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="RESTRICT"), nullable=True
+    )
+    course_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("courses.id", ondelete="RESTRICT"), nullable=True
+    )
+    organization_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("organizations.id", ondelete="RESTRICT"), nullable=True
+    )
+    object_type: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    object_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    source_type: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    source_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    payload: Mapped[dict[str, Any]] = mapped_column(
+        json_document_type(), nullable=False, default=dict
+    )
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    recorded_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    actor = relationship("User")
+    course = relationship("Course", back_populates="activity_events")
+    organization = relationship("Organization")
+
+
+@event.listens_for(Session, "before_flush")
+def _keep_activity_events_append_only(
+    session: Session, _flush_context: object, _instances: object
+) -> None:
+    for activity_event in session.dirty:
+        if isinstance(activity_event, ActivityEvent):
+            raise ValueError(f"ActivityEvent {activity_event.id} is append-only")
+    for activity_event in session.deleted:
+        if isinstance(activity_event, ActivityEvent):
+            raise ValueError(f"ActivityEvent {activity_event.id} is append-only")
+
+
+__all__ = [
+    "ActivityEvent",
+    "CalendarEvent",
+    "CalendarEventVisibility",
+    "NotificationChannel",
+    "NotificationDeliveryMode",
+    "NotificationPreference",
+]

--- a/src/fair_platform/backend/data/models/lms_gradebook.py
+++ b/src/fair_platform/backend/data/models/lms_gradebook.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UUID as SAUUID,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
+
+from ..database import Base
+from .types import json_document_type
+
+if TYPE_CHECKING:
+    from .course import Course
+    from .user import User
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _decimal_points(value: Any, *, positive: bool, field_name: str) -> Decimal:
+    if isinstance(value, bool) or not isinstance(value, (int, float, Decimal)):
+        raise ValueError(f"{field_name} must be a numeric points value")
+    try:
+        points = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"{field_name} must be a finite points value") from exc
+    if not points.is_finite() or (points <= 0 if positive else points < 0):
+        qualifier = "positive" if positive else "non-negative"
+        raise ValueError(f"{field_name} must be a {qualifier} points value")
+    return points
+
+
+class GradeAggregationStrategy(str, Enum):
+    sum = "sum"
+    weighted_mean = "weighted_mean"
+    simple_mean = "simple_mean"
+    highest = "highest"
+
+
+class GradeEntryStatus(str, Enum):
+    graded = "graded"
+    missing = "missing"
+    excused = "excused"
+
+
+class GradeReleaseState(str, Enum):
+    unreleased = "unreleased"
+    released = "released"
+
+
+class GradeCategory(Base):
+    __tablename__ = "grade_categories"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["parent_category_id", "course_id"],
+            ["grade_categories.id", "grade_categories.course_id"],
+            name="fk_grade_categories_parent_course",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "course_id", "position", name="uq_grade_categories_course_position"
+        ),
+        UniqueConstraint("id", "course_id", name="uq_grade_categories_id_course"),
+        CheckConstraint(
+            "position >= 0", name="ck_grade_categories_position_non_negative"
+        ),
+        CheckConstraint(
+            "weight IS NULL OR weight >= 0", name="ck_grade_categories_weight"
+        ),
+        CheckConstraint(
+            "aggregation_strategy IN "
+            "('sum', 'weighted_mean', 'simple_mean', 'highest')",
+            name="ck_grade_categories_aggregation_strategy",
+        ),
+        Index("ix_grade_categories_course_parent", "course_id", "parent_category_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    course_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("courses.id", ondelete="CASCADE"), nullable=False
+    )
+    parent_category_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    aggregation_strategy: Mapped[GradeAggregationStrategy] = mapped_column(
+        String(32), nullable=False, default=GradeAggregationStrategy.sum
+    )
+    weight: Mapped[Optional[Decimal]] = mapped_column(Numeric(12, 6), nullable=True)
+    calculation_policy: Mapped[dict[str, Any]] = mapped_column(
+        json_document_type(), nullable=False, default=dict
+    )
+    copied_from_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("grade_categories.id", ondelete="RESTRICT"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    course: Mapped["Course"] = relationship("Course", back_populates="grade_categories")
+    parent: Mapped[Optional["GradeCategory"]] = relationship(
+        "GradeCategory",
+        remote_side=[id, course_id],
+        foreign_keys=[parent_category_id, course_id],
+        overlaps="course,grade_categories",
+    )
+    copied_from: Mapped[Optional["GradeCategory"]] = relationship(
+        "GradeCategory", remote_side=[id], foreign_keys=[copied_from_id]
+    )
+    items: Mapped[list["GradeItem"]] = relationship(
+        "GradeItem",
+        back_populates="category",
+        order_by="GradeItem.position",
+        overlaps="grade_items",
+    )
+
+    @validates("weight")
+    def validate_weight(self, _key: str, value: Any) -> Optional[Decimal]:
+        if value is None:
+            return None
+        return _decimal_points(value, positive=False, field_name="weight")
+
+
+class GradeItem(Base):
+    __tablename__ = "grade_items"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["category_id", "course_id"],
+            ["grade_categories.id", "grade_categories.course_id"],
+            name="fk_grade_items_category_course",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "course_id", "position", name="uq_grade_items_course_position"
+        ),
+        UniqueConstraint("id", "course_id", name="uq_grade_items_id_course"),
+        UniqueConstraint(
+            "course_id",
+            "source_type",
+            "source_id",
+            name="uq_grade_items_course_source",
+        ),
+        CheckConstraint("position >= 0", name="ck_grade_items_position_non_negative"),
+        CheckConstraint("max_points > 0", name="ck_grade_items_max_points_positive"),
+        CheckConstraint("weight IS NULL OR weight >= 0", name="ck_grade_items_weight"),
+        CheckConstraint(
+            "(source_type IS NULL AND source_id IS NULL) OR "
+            "(source_type IS NOT NULL AND source_id IS NOT NULL)",
+            name="ck_grade_items_source_pair",
+        ),
+        Index("ix_grade_items_course_category", "course_id", "category_id"),
+        Index("ix_grade_items_source", "source_type", "source_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    course_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("courses.id", ondelete="CASCADE"), nullable=False
+    )
+    category_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    max_points: Mapped[Decimal] = mapped_column(Numeric(12, 4), nullable=False)
+    weight: Mapped[Optional[Decimal]] = mapped_column(Numeric(12, 6), nullable=True)
+    calculation_policy: Mapped[dict[str, Any]] = mapped_column(
+        json_document_type(), nullable=False, default=dict
+    )
+    release_policy: Mapped[dict[str, Any]] = mapped_column(
+        json_document_type(), nullable=False, default=dict
+    )
+    source_type: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    source_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    copied_from_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("grade_items.id", ondelete="RESTRICT"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    course: Mapped["Course"] = relationship(
+        "Course", back_populates="grade_items", overlaps="items"
+    )
+    category: Mapped[Optional[GradeCategory]] = relationship(
+        "GradeCategory",
+        back_populates="items",
+        foreign_keys=[category_id, course_id],
+        overlaps="course,grade_items",
+    )
+    copied_from: Mapped[Optional["GradeItem"]] = relationship(
+        "GradeItem", remote_side=[id], foreign_keys=[copied_from_id]
+    )
+    entries: Mapped[list["GradeEntry"]] = relationship(
+        "GradeEntry", back_populates="grade_item", cascade="all, delete-orphan"
+    )
+
+    @validates("max_points")
+    def validate_max_points(self, _key: str, value: Any) -> Decimal:
+        return _decimal_points(value, positive=True, field_name="max_points")
+
+    @validates("weight")
+    def validate_weight(self, _key: str, value: Any) -> Optional[Decimal]:
+        if value is None:
+            return None
+        return _decimal_points(value, positive=False, field_name="weight")
+
+
+class GradeEntry(Base):
+    """The current release-aware points projection for one learner and item.
+
+    Draft scores never belong here. Assignment grading writes an entry only
+    when points are returned, and records the published submission as source.
+    """
+
+    __tablename__ = "grade_entries"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["grade_item_id", "course_id"],
+            ["grade_items.id", "grade_items.course_id"],
+            name="fk_grade_entries_item_course",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["user_id", "course_id"],
+            ["enrollments.user_id", "enrollments.course_id"],
+            name="fk_grade_entries_enrollment",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint("grade_item_id", "user_id", name="uq_grade_entries_item_user"),
+        CheckConstraint(
+            "(status = 'graded' AND points_earned IS NOT NULL) OR "
+            "(status IN ('missing', 'excused') AND points_earned IS NULL)",
+            name="ck_grade_entries_status_points",
+        ),
+        CheckConstraint(
+            "points_earned IS NULL OR points_earned >= 0",
+            name="ck_grade_entries_points_non_negative",
+        ),
+        CheckConstraint(
+            "release_state IN ('unreleased', 'released')",
+            name="ck_grade_entries_release_state",
+        ),
+        CheckConstraint(
+            "(release_state = 'unreleased' AND released_at IS NULL) OR "
+            "(release_state = 'released' AND released_at IS NOT NULL)",
+            name="ck_grade_entries_release_timestamp",
+        ),
+        CheckConstraint(
+            "(source_type IS NULL AND source_id IS NULL) OR "
+            "(source_type IS NOT NULL AND source_id IS NOT NULL)",
+            name="ck_grade_entries_source_pair",
+        ),
+        Index("ix_grade_entries_course_user", "course_id", "user_id"),
+        Index("ix_grade_entries_release", "course_id", "release_state"),
+        Index("ix_grade_entries_source", "source_type", "source_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    course_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    grade_item_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    user_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    status: Mapped[GradeEntryStatus] = mapped_column(String(32), nullable=False)
+    points_earned: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(12, 4), nullable=True
+    )
+    release_state: Mapped[GradeReleaseState] = mapped_column(
+        String(32), nullable=False, default=GradeReleaseState.unreleased
+    )
+    released_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    graded_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    source_type: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    source_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    source_version: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    recorded_by_user_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="RESTRICT"), nullable=True
+    )
+    note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    grade_item: Mapped[GradeItem] = relationship("GradeItem", back_populates="entries")
+    recorded_by: Mapped[Optional["User"]] = relationship(
+        "User", foreign_keys=[recorded_by_user_id]
+    )
+
+    @validates("points_earned")
+    def validate_points_earned(self, _key: str, value: Any) -> Optional[Decimal]:
+        if value is None:
+            return None
+        return _decimal_points(value, positive=False, field_name="points_earned")
+
+
+__all__ = [
+    "GradeAggregationStrategy",
+    "GradeCategory",
+    "GradeEntry",
+    "GradeEntryStatus",
+    "GradeItem",
+    "GradeReleaseState",
+]

--- a/src/fair_platform/backend/data/models/lms_organization.py
+++ b/src/fair_platform/backend/data/models/lms_organization.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    String,
+    Text,
+    UUID as SAUUID,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..database import Base
+from .types import json_document_type
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class OrganizationMembershipRole(str, Enum):
+    owner = "owner"
+    admin = "admin"
+    member = "member"
+
+
+class MembershipStatus(str, Enum):
+    active = "active"
+    inactive = "inactive"
+
+
+class CourseGroupMembershipRole(str, Enum):
+    member = "member"
+    leader = "leader"
+
+
+class ExternalIdentifierSubjectType(str, Enum):
+    user = "user"
+    course = "course"
+    cohort = "cohort"
+
+
+class Organization(Base):
+    __tablename__ = "organizations"
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    slug: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    attributes: Mapped[dict[str, Any]] = mapped_column(
+        json_document_type(), nullable=False, default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    memberships: Mapped[list["OrganizationMembership"]] = relationship(
+        "OrganizationMembership",
+        back_populates="organization",
+        cascade="all, delete-orphan",
+    )
+    cohorts: Mapped[list["Cohort"]] = relationship(
+        "Cohort", back_populates="organization", cascade="all, delete-orphan"
+    )
+    courses = relationship("Course", back_populates="organization")
+
+
+class OrganizationMembership(Base):
+    __tablename__ = "organization_memberships"
+    __table_args__ = (
+        UniqueConstraint(
+            "organization_id",
+            "user_id",
+            name="uq_organization_memberships_organization_user",
+        ),
+        CheckConstraint(
+            "role IN ('owner', 'admin', 'member')",
+            name="ck_organization_memberships_role",
+        ),
+        CheckConstraint(
+            "status IN ('active', 'inactive')",
+            name="ck_organization_memberships_status",
+        ),
+        Index("ix_organization_memberships_user_status", "user_id", "status"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    organization_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+    )
+    role: Mapped[OrganizationMembershipRole] = mapped_column(
+        String(32), nullable=False, default=OrganizationMembershipRole.member
+    )
+    status: Mapped[MembershipStatus] = mapped_column(
+        String(32), nullable=False, default=MembershipStatus.active
+    )
+    joined_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    organization: Mapped[Organization] = relationship(
+        "Organization", back_populates="memberships"
+    )
+
+
+class Cohort(Base):
+    __tablename__ = "cohorts"
+    __table_args__ = (
+        UniqueConstraint(
+            "organization_id", "name", name="uq_cohorts_organization_name"
+        ),
+        UniqueConstraint("id", "organization_id", name="uq_cohorts_id_organization"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    organization_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    organization: Mapped[Organization] = relationship(
+        "Organization", back_populates="cohorts"
+    )
+    memberships: Mapped[list["CohortMembership"]] = relationship(
+        "CohortMembership", back_populates="cohort", cascade="all, delete-orphan"
+    )
+
+
+class CohortMembership(Base):
+    __tablename__ = "cohort_memberships"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["cohort_id", "organization_id"],
+            ["cohorts.id", "cohorts.organization_id"],
+            name="fk_cohort_memberships_cohort_organization",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["organization_id", "user_id"],
+            [
+                "organization_memberships.organization_id",
+                "organization_memberships.user_id",
+            ],
+            name="fk_cohort_memberships_organization_user",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "cohort_id", "user_id", name="uq_cohort_memberships_cohort_user"
+        ),
+        CheckConstraint(
+            "status IN ('active', 'inactive')",
+            name="ck_cohort_memberships_status",
+        ),
+        Index("ix_cohort_memberships_user_status", "user_id", "status"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    organization_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    cohort_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    user_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    status: Mapped[MembershipStatus] = mapped_column(
+        String(32), nullable=False, default=MembershipStatus.active
+    )
+    joined_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    cohort: Mapped[Cohort] = relationship("Cohort", back_populates="memberships")
+
+
+class CourseGroup(Base):
+    __tablename__ = "course_groups"
+    __table_args__ = (
+        UniqueConstraint("course_id", "name", name="uq_course_groups_course_name"),
+        UniqueConstraint("id", "course_id", name="uq_course_groups_id_course"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    course_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("courses.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    course = relationship("Course", back_populates="groups")
+    memberships: Mapped[list["CourseGroupMembership"]] = relationship(
+        "CourseGroupMembership",
+        back_populates="group",
+        cascade="all, delete-orphan",
+    )
+
+
+class CourseGroupMembership(Base):
+    __tablename__ = "course_group_memberships"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["group_id", "course_id"],
+            ["course_groups.id", "course_groups.course_id"],
+            name="fk_course_group_memberships_group_course",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["user_id", "course_id"],
+            ["enrollments.user_id", "enrollments.course_id"],
+            name="fk_course_group_memberships_enrollment",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "group_id", "user_id", name="uq_course_group_memberships_group_user"
+        ),
+        CheckConstraint(
+            "role IN ('member', 'leader')",
+            name="ck_course_group_memberships_role",
+        ),
+        Index("ix_course_group_memberships_course_user", "course_id", "user_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    course_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    group_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    user_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    role: Mapped[CourseGroupMembershipRole] = mapped_column(
+        String(32), nullable=False, default=CourseGroupMembershipRole.member
+    )
+    joined_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    group: Mapped[CourseGroup] = relationship(
+        "CourseGroup", back_populates="memberships"
+    )
+
+
+class ExternalIdentifier(Base):
+    """A scoped mapping from an institutional identifier to one FAIR resource."""
+
+    __tablename__ = "external_identifiers"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["organization_id", "user_id"],
+            [
+                "organization_memberships.organization_id",
+                "organization_memberships.user_id",
+            ],
+            name="fk_external_identifiers_organization_user",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["course_id", "organization_id"],
+            ["courses.id", "courses.organization_id"],
+            name="fk_external_identifiers_course_organization",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["cohort_id", "organization_id"],
+            ["cohorts.id", "cohorts.organization_id"],
+            name="fk_external_identifiers_cohort_organization",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "organization_id",
+            "system",
+            "subject_type",
+            "external_id",
+            name="uq_external_identifiers_external",
+        ),
+        UniqueConstraint(
+            "organization_id",
+            "system",
+            "user_id",
+            name="uq_external_identifiers_user",
+        ),
+        UniqueConstraint(
+            "organization_id",
+            "system",
+            "course_id",
+            name="uq_external_identifiers_course",
+        ),
+        UniqueConstraint(
+            "organization_id",
+            "system",
+            "cohort_id",
+            name="uq_external_identifiers_cohort",
+        ),
+        CheckConstraint(
+            "(subject_type = 'user' AND user_id IS NOT NULL "
+            "AND course_id IS NULL AND cohort_id IS NULL) OR "
+            "(subject_type = 'course' AND course_id IS NOT NULL "
+            "AND user_id IS NULL AND cohort_id IS NULL) OR "
+            "(subject_type = 'cohort' AND cohort_id IS NOT NULL "
+            "AND user_id IS NULL AND course_id IS NULL)",
+            name="ck_external_identifiers_subject",
+        ),
+        Index("ix_external_identifiers_lookup", "system", "external_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    organization_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    system: Mapped[str] = mapped_column(String(128), nullable=False)
+    subject_type: Mapped[ExternalIdentifierSubjectType] = mapped_column(
+        String(32), nullable=False
+    )
+    external_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    user_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    course_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    cohort_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    attributes: Mapped[dict[str, Any]] = mapped_column(
+        json_document_type(), nullable=False, default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+
+__all__ = [
+    "Cohort",
+    "CohortMembership",
+    "CourseGroup",
+    "CourseGroupMembership",
+    "CourseGroupMembershipRole",
+    "ExternalIdentifier",
+    "ExternalIdentifierSubjectType",
+    "MembershipStatus",
+    "Organization",
+    "OrganizationMembership",
+    "OrganizationMembershipRole",
+]

--- a/src/fair_platform/backend/data/models/lms_progress.py
+++ b/src/fair_platform/backend/data/models/lms_progress.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    String,
+    UUID as SAUUID,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..database import Base
+from .types import json_document_type
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ItemCompletionStatus(str, Enum):
+    not_started = "not_started"
+    in_progress = "in_progress"
+    completed = "completed"
+
+
+class CompletionRule(Base):
+    """One ordered condition that contributes to a course item's completion."""
+
+    __tablename__ = "completion_rules"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["course_item_id", "course_id"],
+            ["course_items.id", "course_items.course_id"],
+            name="fk_completion_rules_item_course",
+            ondelete="CASCADE",
+        ),
+        UniqueConstraint(
+            "course_item_id", "position", name="uq_completion_rules_item_position"
+        ),
+        CheckConstraint(
+            "position >= 0", name="ck_completion_rules_position_non_negative"
+        ),
+        Index("ix_completion_rules_course_type", "course_id", "rule_type"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    course_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    course_item_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    rule_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    config: Mapped[dict[str, Any]] = mapped_column(
+        json_document_type(), nullable=False, default=dict
+    )
+    is_required: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    course_item = relationship("CourseItem")
+
+
+class UserItemCompletion(Base):
+    """The current completion projection for an enrolled learner."""
+
+    __tablename__ = "user_item_completions"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["course_item_id", "course_id"],
+            ["course_items.id", "course_items.course_id"],
+            name="fk_user_item_completions_item_course",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["user_id", "course_id"],
+            ["enrollments.user_id", "enrollments.course_id"],
+            name="fk_user_item_completions_enrollment",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "course_item_id",
+            "user_id",
+            name="uq_user_item_completions_item_user",
+        ),
+        CheckConstraint(
+            "status IN ('not_started', 'in_progress', 'completed')",
+            name="ck_user_item_completions_status",
+        ),
+        CheckConstraint(
+            "(status = 'completed' AND completed_at IS NOT NULL) OR "
+            "(status != 'completed' AND completed_at IS NULL)",
+            name="ck_user_item_completions_timestamp",
+        ),
+        CheckConstraint(
+            "(source_type IS NULL AND source_id IS NULL) OR "
+            "(source_type IS NOT NULL AND source_id IS NOT NULL)",
+            name="ck_user_item_completions_source_pair",
+        ),
+        Index("ix_user_item_completions_course_user", "course_id", "user_id"),
+        Index("ix_user_item_completions_course_status", "course_id", "status"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    course_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    course_item_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    user_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    status: Mapped[ItemCompletionStatus] = mapped_column(
+        String(32), nullable=False, default=ItemCompletionStatus.not_started
+    )
+    completed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    source_type: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    source_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True)
+    evidence: Mapped[dict[str, Any]] = mapped_column(
+        json_document_type(), nullable=False, default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    course_item = relationship("CourseItem")
+
+
+class AvailabilityRule(Base):
+    """One ordered prerequisite/availability predicate for a course item."""
+
+    __tablename__ = "availability_rules"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["course_item_id", "course_id"],
+            ["course_items.id", "course_items.course_id"],
+            name="fk_availability_rules_item_course",
+            ondelete="CASCADE",
+        ),
+        UniqueConstraint(
+            "course_item_id", "position", name="uq_availability_rules_item_position"
+        ),
+        CheckConstraint(
+            "position >= 0", name="ck_availability_rules_position_non_negative"
+        ),
+        Index("ix_availability_rules_course_type", "course_id", "rule_type"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    course_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    course_item_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False)
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    rule_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    config: Mapped[dict[str, Any]] = mapped_column(
+        json_document_type(), nullable=False, default=dict
+    )
+    is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    course_item = relationship("CourseItem")
+
+
+__all__ = [
+    "AvailabilityRule",
+    "CompletionRule",
+    "ItemCompletionStatus",
+    "UserItemCompletion",
+]

--- a/tests/test_lms_primitives.py
+++ b/tests/test_lms_primitives.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from fair_platform.backend.data.models import (
+    ActivityEvent,
+    CalendarEvent,
+    Cohort,
+    CohortMembership,
+    Course,
+    CourseGroup,
+    CourseGroupMembership,
+    CourseItem,
+    CourseSection,
+    Enrollment,
+    ExternalIdentifier,
+    GradeCategory,
+    GradeEntry,
+    GradeItem,
+    Organization,
+    OrganizationMembership,
+    User,
+    UserItemCompletion,
+    UserRole,
+)
+
+
+def _user(*, role: UserRole = UserRole.student) -> User:
+    return User(
+        id=uuid4(),
+        name="LMS primitives user",
+        email=f"{uuid4()}@example.test",
+        role=role,
+    )
+
+
+def _course(instructor: User, *, name: str, organization_id=None) -> Course:
+    return Course(
+        id=uuid4(),
+        name=name,
+        instructor_id=instructor.id,
+        organization_id=organization_id,
+    )
+
+
+def _enroll(user: User, course: Course) -> Enrollment:
+    return Enrollment(id=uuid4(), user_id=user.id, course_id=course.id)
+
+
+def test_course_content_is_stably_ordered_and_course_scoped(test_db) -> None:
+    with test_db() as session:
+        instructor = _user(role=UserRole.instructor)
+        first_course = _course(instructor, name="First")
+        second_course = _course(instructor, name="Second")
+        session.add_all([instructor, first_course, second_course])
+        session.flush()
+
+        section = CourseSection(
+            course_id=first_course.id,
+            title="Week 1",
+            position=0,
+            visibility="published",
+        )
+        session.add(section)
+        session.flush()
+
+        item = CourseItem(
+            course_id=first_course.id,
+            section_id=section.id,
+            title="Assignment",
+            position=0,
+            kind="activity",
+            visibility="published",
+            resource_type="assignment",
+            resource_id=uuid4(),
+            payload_schema_uri="urn:fair:course-item:assignment:v1",
+            payload={"show_description": True},
+        )
+        session.add(item)
+        session.commit()
+
+        assert first_course.sections[0].items[0].resource_type == "assignment"
+        assert first_course.sections[0].items[0].payload_schema_uri.endswith(":v1")
+
+        session.add(
+            CourseItem(
+                course_id=second_course.id,
+                section_id=section.id,
+                title="Cross-course item",
+                position=1,
+                kind="quiz",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+def test_course_content_positions_are_unique_per_parent(test_db) -> None:
+    with test_db() as session:
+        instructor = _user(role=UserRole.instructor)
+        course = _course(instructor, name="Ordering")
+        session.add_all([instructor, course])
+        session.flush()
+        session.add_all(
+            [
+                CourseSection(course_id=course.id, title="One", position=0),
+                CourseSection(course_id=course.id, title="Duplicate", position=0),
+            ]
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        {"type": "percentage", "value": 100},
+        {"type": "points", "value": 100},
+        "100",
+        True,
+        0,
+        -1,
+        float("inf"),
+        float("nan"),
+    ],
+)
+def test_grade_item_rejects_noncanonical_point_maximums(invalid) -> None:
+    with pytest.raises(ValueError, match="max_points"):
+        GradeItem(
+            course_id=uuid4(),
+            title="Invalid grade item",
+            position=0,
+            max_points=invalid,
+        )
+
+
+def test_grade_entries_store_points_and_release_state_only(test_db) -> None:
+    with test_db() as session:
+        instructor = _user(role=UserRole.instructor)
+        learner = _user()
+        course = _course(instructor, name="Gradebook")
+        session.add_all([instructor, learner, course])
+        session.flush()
+        session.add(_enroll(learner, course))
+        category = GradeCategory(
+            course_id=course.id,
+            name="Assignments",
+            position=0,
+            aggregation_strategy="weighted_mean",
+            weight=1,
+            calculation_policy={"drop_lowest": 1},
+        )
+        session.add(category)
+        session.flush()
+        item = GradeItem(
+            course_id=course.id,
+            category_id=category.id,
+            title="A1",
+            position=0,
+            max_points=100,
+            source_type="assignment",
+            source_id=uuid4(),
+        )
+        session.add(item)
+        session.flush()
+        returned_at = datetime.now(timezone.utc)
+        entry = GradeEntry(
+            course_id=course.id,
+            grade_item_id=item.id,
+            user_id=learner.id,
+            status="graded",
+            points_earned=87.5,
+            release_state="released",
+            released_at=returned_at,
+            graded_at=returned_at,
+            source_type="submission",
+            source_id=uuid4(),
+            source_version="published_score:v1",
+            recorded_by_user_id=instructor.id,
+        )
+        session.add(entry)
+        session.commit()
+
+        assert float(entry.points_earned) == 87.5
+        assert item.category is not None
+        assert item.category.id == category.id
+        assert category.items[0].id == item.id
+        assert entry.release_state == "released"
+        assert entry.source_version == "published_score:v1"
+        assert "percentage" not in GradeEntry.__table__.columns
+        assert "letter" not in GradeEntry.__table__.columns
+        assert "pass_fail" not in GradeEntry.__table__.columns
+
+
+def test_grade_entry_requires_item_and_enrollment_in_same_course(test_db) -> None:
+    with test_db() as session:
+        instructor = _user(role=UserRole.instructor)
+        learner = _user()
+        first_course = _course(instructor, name="First")
+        second_course = _course(instructor, name="Second")
+        session.add_all([instructor, learner, first_course, second_course])
+        session.flush()
+        session.add(_enroll(learner, second_course))
+        item = GradeItem(
+            course_id=first_course.id,
+            title="A1",
+            position=0,
+            max_points=100,
+        )
+        session.add(item)
+        session.flush()
+        session.add(
+            GradeEntry(
+                course_id=second_course.id,
+                grade_item_id=item.id,
+                user_id=learner.id,
+                status="missing",
+                release_state="unreleased",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+def test_grade_category_hierarchy_cannot_cross_courses(test_db) -> None:
+    with test_db() as session:
+        instructor = _user(role=UserRole.instructor)
+        first_course = _course(instructor, name="First hierarchy")
+        second_course = _course(instructor, name="Second hierarchy")
+        session.add_all([instructor, first_course, second_course])
+        session.flush()
+        parent = GradeCategory(course_id=first_course.id, name="Parent", position=0)
+        session.add(parent)
+        session.flush()
+        valid_child = GradeCategory(
+            course_id=first_course.id,
+            parent_category_id=parent.id,
+            name="Valid child",
+            position=1,
+        )
+        session.add(valid_child)
+        session.flush()
+        assert valid_child.parent is not None
+        assert valid_child.parent.id == parent.id
+        child = GradeCategory(
+            course_id=second_course.id,
+            parent_category_id=parent.id,
+            name="Cross-course child",
+            position=0,
+        )
+        session.add(child)
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+def test_group_and_completion_membership_cannot_cross_courses(test_db) -> None:
+    with test_db() as session:
+        instructor = _user(role=UserRole.instructor)
+        learner = _user()
+        first_course = _course(instructor, name="First")
+        second_course = _course(instructor, name="Second")
+        session.add_all([instructor, learner, first_course, second_course])
+        session.flush()
+        session.add(_enroll(learner, second_course))
+        group = CourseGroup(course_id=first_course.id, name="Team A")
+        section = CourseSection(course_id=first_course.id, title="Week 1", position=0)
+        session.add_all([group, section])
+        session.flush()
+        item = CourseItem(
+            course_id=first_course.id,
+            section_id=section.id,
+            title="Read",
+            position=0,
+            kind="page",
+        )
+        session.add(item)
+        session.flush()
+
+        session.add(
+            CourseGroupMembership(
+                course_id=second_course.id,
+                group_id=group.id,
+                user_id=learner.id,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.flush()
+        session.rollback()
+
+    with test_db() as session:
+        instructor = _user(role=UserRole.instructor)
+        learner = _user()
+        first_course = _course(instructor, name="First again")
+        second_course = _course(instructor, name="Second again")
+        session.add_all([instructor, learner, first_course, second_course])
+        session.flush()
+        session.add(_enroll(learner, second_course))
+        section = CourseSection(course_id=first_course.id, title="Week 1", position=0)
+        session.add(section)
+        session.flush()
+        item = CourseItem(
+            course_id=first_course.id,
+            section_id=section.id,
+            title="Read",
+            position=0,
+            kind="page",
+        )
+        session.add(item)
+        session.flush()
+        session.add(
+            UserItemCompletion(
+                course_id=first_course.id,
+                course_item_id=item.id,
+                user_id=learner.id,
+                status="not_started",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+def test_cohort_and_external_identifiers_are_organization_scoped(test_db) -> None:
+    with test_db() as session:
+        instructor = _user(role=UserRole.instructor)
+        learner = _user()
+        first_org = Organization(name="First University", slug="first-university")
+        second_org = Organization(name="Second University", slug="second-university")
+        session.add_all([instructor, learner, first_org, second_org])
+        session.flush()
+        session.add(
+            OrganizationMembership(
+                organization_id=first_org.id,
+                user_id=learner.id,
+                role="member",
+            )
+        )
+        cohort = Cohort(organization_id=second_org.id, name="2026")
+        session.add(cohort)
+        session.flush()
+        session.add(
+            CohortMembership(
+                organization_id=first_org.id,
+                cohort_id=cohort.id,
+                user_id=learner.id,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.flush()
+        session.rollback()
+
+    with test_db() as session:
+        instructor = _user(role=UserRole.instructor)
+        org = Organization(name="Third University", slug="third-university")
+        session.add_all([instructor, org])
+        session.flush()
+        course = _course(
+            instructor, name="Institutional course", organization_id=org.id
+        )
+        session.add(course)
+        session.flush()
+        external = ExternalIdentifier(
+            organization_id=org.id,
+            system="sis",
+            subject_type="course",
+            external_id="COURSE-101",
+            course_id=course.id,
+        )
+        session.add(external)
+        session.commit()
+        assert external.external_id == "COURSE-101"
+
+
+def test_activity_events_are_append_only_and_calendar_times_are_valid(test_db) -> None:
+    with test_db() as session:
+        actor = _user(role=UserRole.instructor)
+        session.add(actor)
+        session.flush()
+        activity = ActivityEvent(
+            event_type="course.created",
+            actor_user_id=actor.id,
+            object_type="course",
+            object_id=uuid4(),
+            source_type="course_copy",
+            source_id=uuid4(),
+            payload={"copied_from_id": str(uuid4())},
+        )
+        session.add(activity)
+        session.commit()
+
+        activity.payload = {"changed": True}
+        with pytest.raises(ValueError, match="append-only"):
+            session.commit()
+
+    with test_db() as session:
+        actor = _user(role=UserRole.instructor)
+        session.add(actor)
+        session.flush()
+        starts_at = datetime.now(timezone.utc)
+        session.add(
+            CalendarEvent(
+                owner_user_id=actor.id,
+                title="Invalid",
+                starts_at=starts_at,
+                ends_at=starts_at - timedelta(minutes=1),
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()

--- a/tests/test_lms_primitives_migration.py
+++ b/tests/test_lms_primitives_migration.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import DatabaseError
+
+from fair_platform.backend.data.database import Base
+from fair_platform.backend.data.migrations import (
+    build_alembic_config,
+    run_migrations_to_head,
+    run_migrations_to_revision,
+)
+import fair_platform.backend.data.models  # noqa: F401
+
+
+PRIMITIVES_REVISION = "20260812_0029"
+PRIOR_REVISION = "20260727_0028"
+PRIMITIVE_TABLES = {
+    "activity_events",
+    "availability_rules",
+    "calendar_events",
+    "cohort_memberships",
+    "cohorts",
+    "completion_rules",
+    "course_group_memberships",
+    "course_groups",
+    "course_items",
+    "course_sections",
+    "external_identifiers",
+    "grade_categories",
+    "grade_entries",
+    "grade_items",
+    "notification_preferences",
+    "organization_memberships",
+    "organizations",
+    "user_item_completions",
+}
+
+
+def _database_url(path: Path) -> str:
+    return f"sqlite:///{path.as_posix()}"
+
+
+def _revision(path: Path) -> str:
+    with sqlite3.connect(path) as connection:
+        row = connection.execute(
+            "SELECT version_num FROM alembic_version LIMIT 1"
+        ).fetchone()
+    assert row is not None
+    return row[0]
+
+
+def test_primitives_revision_is_the_sole_head() -> None:
+    script = ScriptDirectory.from_config(build_alembic_config("sqlite:///:memory:"))
+    assert script.get_heads() == [PRIMITIVES_REVISION]
+
+
+def test_upgrade_from_points_head_has_model_column_parity(tmp_path: Path) -> None:
+    database_path = tmp_path / "lms-primitives.sqlite"
+    database_url = _database_url(database_path)
+    run_migrations_to_revision(PRIOR_REVISION, database_url)
+    assert _revision(database_path) == PRIOR_REVISION
+
+    run_migrations_to_head(database_url)
+    assert _revision(database_path) == PRIMITIVES_REVISION
+
+    engine = create_engine(database_url)
+    with engine.connect() as connection:
+        schema = inspect(connection)
+        assert PRIMITIVE_TABLES <= set(schema.get_table_names())
+        assert "organization_id" in {
+            column["name"] for column in schema.get_columns("courses")
+        }
+        for table_name in PRIMITIVE_TABLES:
+            migrated_columns = {
+                column["name"] for column in schema.get_columns(table_name)
+            }
+            assert migrated_columns == set(Base.metadata.tables[table_name].c.keys())
+    engine.dispose()
+
+
+def test_activity_event_trigger_rejects_raw_update_and_delete(tmp_path: Path) -> None:
+    database_path = tmp_path / "activity-events.sqlite"
+    database_url = _database_url(database_path)
+    run_migrations_to_head(database_url)
+
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO activity_events "
+                "(id, event_type, payload, occurred_at, recorded_at) "
+                "VALUES (:id, :event_type, :payload, :occurred_at, :recorded_at)"
+            ),
+            {
+                "id": "00000000000000000000000000000001",
+                "event_type": "course.created",
+                "payload": "{}",
+                "occurred_at": "2026-08-12 12:00:00",
+                "recorded_at": "2026-08-12 12:00:00",
+            },
+        )
+
+    with engine.begin() as connection:
+        with pytest.raises(DatabaseError, match="append-only"):
+            connection.execute(
+                text("UPDATE activity_events SET event_type = 'changed'")
+            )
+    with engine.begin() as connection:
+        with pytest.raises(DatabaseError, match="append-only"):
+            connection.execute(text("DELETE FROM activity_events"))
+    engine.dispose()
+
+
+def test_primitives_migration_downgrades_and_reupgrades_cleanly(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "round-trip.sqlite"
+    database_url = _database_url(database_path)
+    config = build_alembic_config(database_url)
+    run_migrations_to_head(database_url)
+
+    command.downgrade(config, PRIOR_REVISION)
+    assert _revision(database_path) == PRIOR_REVISION
+    engine = create_engine(database_url)
+    with engine.connect() as connection:
+        schema = inspect(connection)
+        assert not (PRIMITIVE_TABLES & set(schema.get_table_names()))
+        assert "organization_id" not in {
+            column["name"] for column in schema.get_columns("courses")
+        }
+    engine.dispose()
+
+    run_migrations_to_head(database_url)
+    assert _revision(database_path) == PRIMITIVES_REVISION
+
+
+def test_primitives_migration_is_explicit() -> None:
+    migration = (
+        Path(__file__).parents[1]
+        / "src/fair_platform/backend/alembic/versions/20260812_0029_lms_primitives.py"
+    ).read_text(encoding="utf-8")
+    assert "Base.metadata.create_all" not in migration
+    assert 'op.create_table(\n        "course_sections"' in migration
+    assert 'op.create_table(\n        "grade_entries"' in migration
+    assert 'op.create_table(\n        "activity_events"' in migration

--- a/tests/test_migration_rehearsal_files.py
+++ b/tests/test_migration_rehearsal_files.py
@@ -113,6 +113,10 @@ def test_destructive_cutover_rejects_downgrade(tmp_path: Path) -> None:
     run_migrations_to_head(database_url)
     with pytest.raises(RuntimeError, match="intentional destructive cutover"):
         command.downgrade(build_alembic_config(database_url), "20260307_0013")
+    # Reversible revisions after the points-only cutover are removed before
+    # the irreversible 20260727_0028 downgrade refuses to continue.
+    assert _read_revision(db_path) == "20260727_0028"
+    run_migrations_to_head(database_url)
     assert _read_revision(db_path) == _alembic_head()
 
 

--- a/tests/test_postgres_compat.py
+++ b/tests/test_postgres_compat.py
@@ -120,6 +120,18 @@ def test_postgres_json_columns_are_jsonb(postgres_database_url: str) -> None:
         ("artifact_versions", "provenance"),
         ("submission_events", "details"),
         ("rubrics", "content"),
+        ("organizations", "attributes"),
+        ("external_identifiers", "attributes"),
+        ("course_items", "payload"),
+        ("completion_rules", "config"),
+        ("availability_rules", "config"),
+        ("user_item_completions", "evidence"),
+        ("grade_categories", "calculation_policy"),
+        ("grade_items", "calculation_policy"),
+        ("grade_items", "release_policy"),
+        ("calendar_events", "recurrence"),
+        ("notification_preferences", "config"),
+        ("activity_events", "payload"),
     ]
 
     with engine.connect() as conn:


### PR DESCRIPTION
## Scope

- Add normalized LMS foundation primitives for course sections/items, grade categories/items/entries, completion and availability, organizations/cohorts/groups/external IDs, calendar events, notification preferences, and append-only activity events.
- Preserve canonical points-only grading and keep draft submission scores outside released grade entries.
- Add explicit SQLite/PostgreSQL-compatible Alembic revision `20260812_0029`, model/migration coverage, PostgreSQL JSONB assertions, and architecture documentation.
- Linear: RD-75 and child slices RD-76, RD-77, RD-78, RD-79, RD-80 in [FAIR LMS Completeness](https://linear.app/aiam/project/fair-lms-completeness-8d0ec0835c4c).

## Non-goals

- No CRUD feature APIs or end-user UI.
- No grade calculations, completion evaluation, notification delivery, SIS synchronization, quiz behavior, or course-copy execution.
- No change to existing assignment routes or published/draft submission behavior.

## Validation

- 93 passed, 3 skipped in the affected backend suite; skipped tests require `POSTGRES_TEST_URL`.
- 21 focused primitives tests passed.
- Alembic upgrade/downgrade/re-upgrade: `0028 -> 0029 -> 0028 -> 0029`.
- Sole Alembic head: `20260812_0029`.
- Ruff format/check, SQLAlchemy mapper warnings-as-errors, docs JSON parse, and `git diff --check` passed.
- PostgreSQL JSONB/static SQL coverage passed; a live PostgreSQL database was not available locally.

## Review guide

1. Review the cross-scope composite foreign keys and stable ordering constraints.
2. Review `GradeEntry` release/source contracts and points-only validators.
3. Review copy provenance/source seams and append-only `ActivityEvent` guards.
4. Review migration parity and round-trip tests.

## Next steps

A1 and A3 are separate follow-up PRs built on these contracts. A2 follows A3; A4 combines A1+A3; A7 follows A4. Each will ultimately target `canary`.