### PR TITLE
feat: add LMS course content builder

### DIFF
--- a/docs/assets/openapi.json
+++ b/docs/assets/openapi.json
@@ -2970,6 +2970,548 @@
         }
       }
     },
+    "/api/lms/courses/{course_id}/content": {
+      "get": {
+        "tags": [
+          "course-content"
+        ],
+        "summary": "Get Course Content",
+        "operationId": "get_course_content_api_lms_courses__course_id__content_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Course Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseContentRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lms/courses/{course_id}/sections": {
+      "post": {
+        "tags": [
+          "course-content"
+        ],
+        "summary": "Create Course Section",
+        "operationId": "create_course_section_api_lms_courses__course_id__sections_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Course Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CourseSectionCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseSectionRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lms/courses/{course_id}/sections/{section_id}": {
+      "patch": {
+        "tags": [
+          "course-content"
+        ],
+        "summary": "Update Course Section",
+        "operationId": "update_course_section_api_lms_courses__course_id__sections__section_id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Course Id"
+            }
+          },
+          {
+            "name": "section_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Section Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CourseSectionUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseSectionRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "course-content"
+        ],
+        "summary": "Delete Course Section",
+        "operationId": "delete_course_section_api_lms_courses__course_id__sections__section_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Course Id"
+            }
+          },
+          {
+            "name": "section_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Section Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lms/courses/{course_id}/sections/order": {
+      "put": {
+        "tags": [
+          "course-content"
+        ],
+        "summary": "Reorder Course Sections",
+        "operationId": "reorder_course_sections_api_lms_courses__course_id__sections_order_put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Course Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExactOrderUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CourseSectionRead"
+                  },
+                  "title": "Response Reorder Course Sections Api Lms Courses  Course Id  Sections Order Put"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lms/courses/{course_id}/sections/{section_id}/items": {
+      "post": {
+        "tags": [
+          "course-content"
+        ],
+        "summary": "Create Course Item",
+        "operationId": "create_course_item_api_lms_courses__course_id__sections__section_id__items_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Course Id"
+            }
+          },
+          {
+            "name": "section_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Section Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CourseItemCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseItemRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lms/courses/{course_id}/items/{item_id}": {
+      "patch": {
+        "tags": [
+          "course-content"
+        ],
+        "summary": "Update Course Item",
+        "operationId": "update_course_item_api_lms_courses__course_id__items__item_id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Course Id"
+            }
+          },
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CourseItemUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseItemRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "course-content"
+        ],
+        "summary": "Delete Course Item",
+        "operationId": "delete_course_item_api_lms_courses__course_id__items__item_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Course Id"
+            }
+          },
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lms/courses/{course_id}/sections/{section_id}/items/order": {
+      "put": {
+        "tags": [
+          "course-content"
+        ],
+        "summary": "Reorder Course Items",
+        "operationId": "reorder_course_items_api_lms_courses__course_id__sections__section_id__items_order_put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Course Id"
+            }
+          },
+          {
+            "name": "section_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Section Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExactOrderUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CourseItemRead"
+                  },
+                  "title": "Response Reorder Course Items Api Lms Courses  Course Id  Sections  Section Id  Items Order Put"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/system/config": {
       "get": {
         "tags": [
@@ -8267,6 +8809,42 @@
         ],
         "title": "CourseCommentRead"
       },
+      "CourseContentRead": {
+        "properties": {
+          "courseId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Courseid"
+          },
+          "canManage": {
+            "type": "boolean",
+            "title": "Canmanage"
+          },
+          "sections": {
+            "items": {
+              "$ref": "#/components/schemas/CourseSectionRead"
+            },
+            "type": "array",
+            "title": "Sections"
+          }
+        },
+        "type": "object",
+        "required": [
+          "courseId",
+          "canManage",
+          "sections"
+        ],
+        "title": "CourseContentRead"
+      },
+      "CourseContentVisibility": {
+        "type": "string",
+        "enum": [
+          "draft",
+          "published",
+          "hidden"
+        ],
+        "title": "CourseContentVisibility"
+      },
       "CourseCreate": {
         "properties": {
           "name": {
@@ -8469,6 +9047,199 @@
           "rows"
         ],
         "title": "CourseGradebook"
+      },
+      "CourseItemCreate": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Title"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "heading",
+              "page",
+              "link",
+              "file",
+              "assignment"
+            ],
+            "title": "Kind"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/CourseContentVisibility",
+            "default": "draft"
+          },
+          "resourceId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resourceid"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Payload"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "kind"
+        ],
+        "title": "CourseItemCreate"
+      },
+      "CourseItemRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "courseId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Courseid"
+          },
+          "sectionId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Sectionid"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "position": {
+            "type": "integer",
+            "title": "Position"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "heading",
+              "page",
+              "link",
+              "file",
+              "assignment"
+            ],
+            "title": "Kind"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/CourseContentVisibility"
+          },
+          "resourceType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resourcetype"
+          },
+          "resourceId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resourceid"
+          },
+          "payloadSchemaUri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payloadschemauri"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Payload"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Createdat"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updatedat"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "courseId",
+          "sectionId",
+          "title",
+          "position",
+          "kind",
+          "visibility",
+          "payload",
+          "createdAt",
+          "updatedAt"
+        ],
+        "title": "CourseItemRead"
+      },
+      "CourseItemUpdate": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "visibility": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CourseContentVisibility"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "payload": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payload"
+          }
+        },
+        "type": "object",
+        "title": "CourseItemUpdate"
       },
       "CourseMembershipRole": {
         "type": "string",
@@ -8716,6 +9487,141 @@
           "updatedAt"
         ],
         "title": "CourseRead"
+      },
+      "CourseSectionCreate": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Title"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/CourseContentVisibility",
+            "default": "draft"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "CourseSectionCreate"
+      },
+      "CourseSectionRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "courseId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Courseid"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary"
+          },
+          "position": {
+            "type": "integer",
+            "title": "Position"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/CourseContentVisibility"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Createdat"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updatedat"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CourseItemRead"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "courseId",
+          "title",
+          "position",
+          "visibility",
+          "createdAt",
+          "updatedAt",
+          "items"
+        ],
+        "title": "CourseSectionRead"
+      },
+      "CourseSectionUpdate": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary"
+          },
+          "visibility": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CourseContentVisibility"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "CourseSectionUpdate"
       },
       "CourseSettingsUpdate": {
         "properties": {
@@ -8993,6 +9899,23 @@
           "role"
         ],
         "title": "EnrollmentUpdate"
+      },
+      "ExactOrderUpdate": {
+        "properties": {
+          "orderedIds": {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array",
+            "title": "Orderedids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "orderedIds"
+        ],
+        "title": "ExactOrderUpdate"
       },
       "ExecutionArtifactCreate": {
         "properties": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,6 +58,7 @@
                 "group": "Platform",
                 "pages": [
                   "en/platform/courses",
+                  "en/platform/course-content",
                   "en/platform/assignments",
                   "en/platform/lms-primitives",
                   "en/platform/flows",

--- a/docs/en/platform/course-content.md
+++ b/docs/en/platform/course-content.md
@@ -1,0 +1,35 @@
+---
+title: Course content
+description: Build an ordered student-facing course outline with sections, pages, links, files, and assignments.
+---
+
+The **Content** tab gives instructors one ordered outline for the resources students need. It complements the existing **Assignments** tab; creating or organizing content does not replace assignment creation or change assignment submissions and grading.
+
+## Build an outline
+
+Course staff can:
+
+- Add, edit, delete, and reorder sections.
+- Add headings, Markdown pages, web links, course-visible files, or an existing assignment.
+- Move sections and items with the labelled up and down buttons, including from a keyboard.
+- mark each section or item as **Draft**, **Published**, or **Hidden**.
+
+An assignment or file can appear only once in a course outline. Linked assignments and files remain their original FAIR resources; the outline stores a reference instead of copying them.
+
+## What students see
+
+Students see published sections and published items only. A linked assignment is shown only after that assignment is also published. Draft and hidden content remains available to course staff in the builder.
+
+Files open through FAIR's authenticated artifact access, so course permissions still apply when a student reads or downloads a file.
+
+## Archived courses
+
+An archived course keeps its outline available for reading, but course content cannot be created, edited, deleted, or reordered until the course is restored.
+
+## Reordering contract
+
+Each reorder request sends the complete ordered list of current section IDs or item IDs. FAIR rejects missing, unknown, or duplicate IDs as a conflict, so simultaneous edits cannot silently drop content.
+
+## Existing courses
+
+When this feature is enabled, each existing course receives a default published section. Existing assignments are linked there in a deterministic order; draft assignments remain draft in the outline.

--- a/docs/en/platform/courses.md
+++ b/docs/en/platform/courses.md
@@ -34,12 +34,23 @@ Every course has a unique **Enrollment Code**. This is a simple 4-letter code (l
 ## What's Inside a Course?
 
 Once you've created a course, you can click on it to start adding content:
+- **Content:** Build an ordered outline with sections, pages, links, course files, and existing assignments.
 - **Assignments:** Create the tasks your students need to complete.
 - **Submissions:** See the work your students have turned in.
 - **Grading:** Set up how you want the AI or yourself to grade the work.
 
 ## Next Steps
 <Columns cols={2}>
+    <Card
+      title="Build Course Content"
+      icon="list-tree"
+      href="/en/platform/course-content"
+      arrow="true"
+      cta="Read the guide"
+    >
+      Organize course resources into a published student outline.
+    </Card>
+
     <Card
       title="Create an Assignment"
       icon="file-signature"

--- a/frontend-dev/src/app/courses/course/page.tsx
+++ b/frontend-dev/src/app/courses/course/page.tsx
@@ -18,7 +18,8 @@ import {useAuth} from "@/contexts/auth-context";
 import {usePermission} from "@/hooks/use-permission";
 import {GradebookTab} from "@/app/courses/tabs/gradebook-tab";
 import {StreamTab} from "@/app/courses/tabs/stream-tab";
-type CourseTab = "stream" | "assignments" | "gradebook" | "participants" | "runs" | "artifacts" | "flows" | "capabilities";
+import {CourseContentTab} from "@/app/courses/tabs/content/course-content-tab";
+type CourseTab = "stream" | "content" | "assignments" | "gradebook" | "participants" | "runs" | "artifacts" | "flows" | "capabilities";
 
 export default function CourseDetailPage() {
   const params = useParams<{ courseId: string, tab: string }>()
@@ -44,8 +45,8 @@ export default function CourseDetailPage() {
       instructorId === user.id || canManageUsers || course.membershipRole === 'assistant'
     );
     const visibleTabs: CourseTab[] = isInstructorView
-      ? ["stream", "assignments", "gradebook", "participants", "runs", "artifacts", "flows", "capabilities"]
-      : ["stream", "assignments", "artifacts"];
+      ? ["stream", "content", "assignments", "gradebook", "participants", "runs", "artifacts", "flows", "capabilities"]
+      : ["stream", "content", "assignments", "artifacts"];
     if (!tab || !visibleTabs.includes(tab as CourseTab)) {
       navigate(`assignments`);
     }
@@ -65,8 +66,8 @@ export default function CourseDetailPage() {
   const isCourseAssistant = course.membershipRole === 'assistant';
   const isInstructorView = isCourseOwner || isCourseAdmin || isCourseAssistant;
   const visibleTabs: CourseTab[] = isInstructorView
-    ? ["stream", "assignments", "gradebook", "participants", "runs", "artifacts", "flows", "capabilities"]
-    : ["stream", "assignments", "artifacts"];
+    ? ["stream", "content", "assignments", "gradebook", "participants", "runs", "artifacts", "flows", "capabilities"]
+    : ["stream", "content", "assignments", "artifacts"];
   const currentTab = (tab && visibleTabs.includes(tab as CourseTab) ? tab : "assignments") as CourseTab;
 
   const showEnrollmentControls =
@@ -127,6 +128,7 @@ export default function CourseDetailPage() {
         <ScrollArea className={"w-full border-b"}>
           <TabsList className={"px-8 w-full"}>
             <TabsTrigger value="stream">Stream</TabsTrigger>
+            <TabsTrigger value="content">Content</TabsTrigger>
             <TabsTrigger value="assignments">{t("tabs.assignments")}</TabsTrigger>
             {isInstructorView && <TabsTrigger value="gradebook">Gradebook</TabsTrigger>}
             <TabsTrigger value="artifacts">{t("tabs.artifacts")}</TabsTrigger>
@@ -145,6 +147,14 @@ export default function CourseDetailPage() {
         </TabsContent>
         <TabsContent value={"stream"} className={"px-8"}>
           <StreamTab courseId={courseId as string} canPost={isInstructorView}/>
+        </TabsContent>
+        <TabsContent value={"content"} className={"px-8"}>
+          <CourseContentTab
+            courseId={courseId as string}
+            canManage={isInstructorView}
+            isArchived={course.isArchived}
+            assignments={assignments}
+          />
         </TabsContent>
         {isInstructorView && (
           <TabsContent value={"gradebook"} className={"px-8"}>

--- a/frontend-dev/src/app/courses/tabs/content/course-content-tab.test.tsx
+++ b/frontend-dev/src/app/courses/tabs/content/course-content-tab.test.tsx
@@ -1,0 +1,174 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+
+const mocks = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+  content: vi.fn(),
+  reorderSections: vi.fn(),
+  reorderItems: vi.fn(),
+}))
+
+function mutation(mutate = vi.fn()) {
+  return { mutate, mutateAsync: vi.fn(), isPending: false }
+}
+
+vi.mock('@/lib/api', () => ({
+  default: { get: mocks.apiGet },
+  getApiBaseUrl: () => 'http://localhost:8000/api',
+}))
+
+vi.mock('@/hooks/use-artifacts', () => ({
+  useArtifacts: () => ({
+    data: [{
+      id: 'file-1',
+      title: 'Syllabus',
+      artifactType: 'file',
+      mime: 'text/plain',
+      creatorId: 'owner-1',
+      createdAt: '2026-08-12T00:00:00Z',
+      updatedAt: '2026-08-12T00:00:00Z',
+      status: 'attached',
+      courseId: 'course-1',
+      accessLevel: 'course',
+    }],
+  }),
+}))
+
+vi.mock('@/hooks/use-course-content', () => ({
+  useCourseContent: (...args: unknown[]) => mocks.content(...args),
+  useCreateCourseSection: () => mutation(),
+  useUpdateCourseSection: () => mutation(),
+  useDeleteCourseSection: () => mutation(),
+  useReorderCourseSections: () => mutation(mocks.reorderSections),
+  useCreateCourseItem: () => mutation(),
+  useUpdateCourseItem: () => mutation(),
+  useDeleteCourseItem: () => mutation(),
+  useReorderCourseItems: () => mutation(mocks.reorderItems),
+}))
+
+import { CourseContentTab } from './course-content-tab'
+
+
+const content = {
+  courseId: 'course-1',
+  canManage: true,
+  sections: [
+    {
+      id: 'section-1',
+      courseId: 'course-1',
+      title: 'Overview',
+      summary: 'Start here',
+      position: 0,
+      visibility: 'published',
+      createdAt: '2026-08-12T00:00:00Z',
+      updatedAt: '2026-08-12T00:00:00Z',
+      items: [
+        {
+          id: 'page-1',
+          courseId: 'course-1',
+          sectionId: 'section-1',
+          title: 'Welcome',
+          position: 0,
+          kind: 'page',
+          visibility: 'published',
+          payload: { body: 'Welcome to **FAIR**.' },
+          createdAt: '2026-08-12T00:00:00Z',
+          updatedAt: '2026-08-12T00:00:00Z',
+        },
+        {
+          id: 'file-item-1',
+          courseId: 'course-1',
+          sectionId: 'section-1',
+          title: 'Syllabus',
+          position: 1,
+          kind: 'file',
+          visibility: 'published',
+          resourceId: 'file-1',
+          payload: {},
+          createdAt: '2026-08-12T00:00:00Z',
+          updatedAt: '2026-08-12T00:00:00Z',
+        },
+      ],
+    },
+    {
+      id: 'section-2',
+      courseId: 'course-1',
+      title: 'Week one',
+      position: 1,
+      visibility: 'draft',
+      createdAt: '2026-08-12T00:00:00Z',
+      updatedAt: '2026-08-12T00:00:00Z',
+      items: [],
+    },
+  ],
+}
+
+
+describe('CourseContentTab', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.content.mockReturnValue({ data: content, isLoading: false, isError: false })
+    mocks.apiGet.mockImplementation(async (url: string) => {
+      if (url === '/v1/artifacts/file-1/download') {
+        return { data: { url: '/api/v1/artifact-storage/local/syllabus.txt' } }
+      }
+      return { data: 'Authenticated syllabus text' }
+    })
+  })
+
+  it('offers keyboard-accessible move controls with exact reordered membership', () => {
+    render(
+      <MemoryRouter>
+        <CourseContentTab courseId="course-1" canManage isArchived={false} assignments={[]} />
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move Overview section down' }))
+    expect(mocks.reorderSections).toHaveBeenCalledWith(['section-2', 'section-1'])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move Welcome down' }))
+    expect(mocks.reorderItems).toHaveBeenCalledWith({
+      sectionId: 'section-1',
+      orderedIds: ['file-item-1', 'page-1'],
+    })
+  })
+
+  it('opens protected files through the authenticated artifact action', async () => {
+    render(
+      <MemoryRouter>
+        <CourseContentTab courseId="course-1" canManage isArchived={false} assignments={[]} />
+      </MemoryRouter>,
+    )
+
+    const fileAction = screen.getByRole('button', { name: 'Syllabus' })
+    expect(fileAction.closest('a')).toBeNull()
+    fireEvent.click(fileAction)
+
+    await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith(
+      '/v1/artifacts/file-1/download',
+      expect.objectContaining({ responseType: 'json' }),
+    ))
+    expect(await screen.findByText('Authenticated syllabus text')).toBeInTheDocument()
+  })
+
+  it('renders the published learner outline without staff controls', () => {
+    mocks.content.mockReturnValue({
+      data: { ...content, canManage: false, sections: [content.sections[0]] },
+      isLoading: false,
+      isError: false,
+    })
+    render(
+      <MemoryRouter>
+        <CourseContentTab courseId="course-1" canManage={false} isArchived={false} assignments={[]} />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Welcome' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Add section' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Move Overview/ })).not.toBeInTheDocument()
+  })
+})

--- a/frontend-dev/src/app/courses/tabs/content/course-content-tab.tsx
+++ b/frontend-dev/src/app/courses/tabs/content/course-content-tab.tsx
@@ -1,0 +1,280 @@
+import { useState } from 'react'
+import { ArrowDown, ArrowUp, ExternalLink, FileText, LinkIcon, Pencil, Plus, Trash2 } from 'lucide-react'
+import { Link } from 'react-router-dom'
+
+import { MarkdownRenderer } from '@/components/markdown-renderer'
+import { ArtifactAction } from '@/components/artifact-action'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { LmsArtifact, useArtifacts } from '@/hooks/use-artifacts'
+import { Assignment } from '@/hooks/use-assignments'
+import {
+  CourseItem,
+  CourseSection,
+  CreateItemInput,
+  CreateSectionInput,
+  useCourseContent,
+  useCreateCourseItem,
+  useCreateCourseSection,
+  useDeleteCourseItem,
+  useDeleteCourseSection,
+  useReorderCourseItems,
+  useReorderCourseSections,
+  useUpdateCourseItem,
+  useUpdateCourseSection,
+} from '@/hooks/use-course-content'
+import { ItemDialog } from './item-dialog'
+import { SectionDialog } from './section-dialog'
+
+
+function move<T>(values: T[], index: number, delta: -1 | 1): T[] {
+  const target = index + delta
+  if (target < 0 || target >= values.length) return values
+  const reordered = [...values]
+  ;[reordered[index], reordered[target]] = [reordered[target], reordered[index]]
+  return reordered
+}
+
+
+function ContentItemView({ item, artifacts }: { item: CourseItem; artifacts: LmsArtifact[] }) {
+  if (item.kind === 'heading') {
+    return <h3 className="text-lg font-semibold">{item.title}</h3>
+  }
+  if (item.kind === 'page') {
+    return (
+      <div>
+        <h3 className="font-semibold">{item.title}</h3>
+        <div className="mt-2 text-sm"><MarkdownRenderer>{String(item.payload.body ?? '')}</MarkdownRenderer></div>
+      </div>
+    )
+  }
+  if (item.kind === 'link') {
+    return (
+      <a className="inline-flex items-center gap-2 font-medium text-primary hover:underline" href={String(item.payload.url ?? '')} target="_blank" rel="noreferrer">
+        <LinkIcon className="h-4 w-4" /> {item.title} <ExternalLink className="h-3 w-3" />
+      </a>
+    )
+  }
+  if (item.kind === 'file' && item.resourceId) {
+    const artifact = artifacts.find((candidate) => candidate.id === item.resourceId) ?? {
+      id: item.resourceId,
+      title: item.title,
+      mime: 'application/octet-stream',
+    }
+    return (
+      <ArtifactAction
+        artifact={artifact}
+        icon={FileText}
+        label={item.title}
+        variant="link"
+        className="h-auto p-0 font-medium"
+      />
+    )
+  }
+  if (item.kind === 'assignment' && item.resourceId) {
+    return (
+      <Link className="inline-flex items-center gap-2 font-medium text-primary hover:underline" to={`/courses/${item.courseId}/assignments/${item.resourceId}`}>
+        <FileText className="h-4 w-4" /> {item.title}
+      </Link>
+    )
+  }
+  return <span className="font-medium">{item.title}</span>
+}
+
+
+export function CourseContentTab({
+  courseId,
+  canManage,
+  isArchived,
+  assignments,
+}: {
+  courseId: string
+  canManage: boolean
+  isArchived: boolean
+  assignments: Assignment[]
+}) {
+  const { data: content, isLoading, isError } = useCourseContent(courseId)
+  const { data: artifacts = [] } = useArtifacts({ courseId }, canManage)
+  const createSection = useCreateCourseSection(courseId)
+  const updateSection = useUpdateCourseSection(courseId)
+  const deleteSection = useDeleteCourseSection(courseId)
+  const reorderSections = useReorderCourseSections(courseId)
+  const createItem = useCreateCourseItem(courseId)
+  const updateItem = useUpdateCourseItem(courseId)
+  const deleteItem = useDeleteCourseItem(courseId)
+  const reorderItems = useReorderCourseItems(courseId)
+
+  const [sectionDialogOpen, setSectionDialogOpen] = useState(false)
+  const [editingSection, setEditingSection] = useState<CourseSection | null>(null)
+  const [itemDialogOpen, setItemDialogOpen] = useState(false)
+  const [itemSectionId, setItemSectionId] = useState<string | null>(null)
+  const [editingItem, setEditingItem] = useState<CourseItem | null>(null)
+
+  if (isLoading) return <div className="py-6 text-muted-foreground">Loading course content…</div>
+  if (isError || !content) return <div className="py-6 text-muted-foreground">Course content is unavailable.</div>
+
+  const canEdit = canManage && content.canManage && !isArchived
+  const openNewSection = () => {
+    setEditingSection(null)
+    setSectionDialogOpen(true)
+  }
+  const openNewItem = (sectionId: string) => {
+    setItemSectionId(sectionId)
+    setEditingItem(null)
+    setItemDialogOpen(true)
+  }
+  const openEditItem = (item: CourseItem) => {
+    setItemSectionId(item.sectionId)
+    setEditingItem(item)
+    setItemDialogOpen(true)
+  }
+
+  const saveSection = async (data: CreateSectionInput) => {
+    if (editingSection) {
+      await updateSection.mutateAsync({ id: editingSection.id, data })
+    } else {
+      await createSection.mutateAsync(data)
+    }
+  }
+
+  const saveItem = async (data: CreateItemInput) => {
+    if (editingItem) {
+      await updateItem.mutateAsync({
+        id: editingItem.id,
+        data: {
+          title: data.title,
+          visibility: data.visibility,
+          ...(editingItem.kind === 'page' || editingItem.kind === 'link' ? { payload: data.payload } : {}),
+        },
+      })
+    } else if (itemSectionId) {
+      await createItem.mutateAsync({ sectionId: itemSectionId, data })
+    }
+  }
+
+  const moveSection = (index: number, delta: -1 | 1) => {
+    const ordered = move(content.sections, index, delta)
+    if (ordered !== content.sections) reorderSections.mutate(ordered.map((section) => section.id))
+  }
+
+  const moveItem = (section: CourseSection, index: number, delta: -1 | 1) => {
+    const ordered = move(section.items, index, delta)
+    if (ordered !== section.items) reorderItems.mutate({ sectionId: section.id, orderedIds: ordered.map((item) => item.id) })
+  }
+
+  return (
+    <div className="space-y-5 py-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold">Course content</h2>
+          <p className="text-sm text-muted-foreground">
+            {content.canManage ? 'Organize pages, links, files, and assignments into a student-facing outline.' : 'Work through the course outline in order.'}
+          </p>
+        </div>
+        {canEdit && <Button onClick={openNewSection}><Plus /> Add section</Button>}
+      </div>
+
+      {isArchived && content.canManage && (
+        <div className="rounded-md border bg-muted/50 p-3 text-sm text-muted-foreground">
+          This course is archived. Its content is read-only.
+        </div>
+      )}
+
+      {content.sections.map((section, sectionIndex) => (
+        <section key={section.id} className="rounded-lg border" aria-labelledby={`section-${section.id}`}>
+          <div className="flex items-start gap-3 border-b bg-muted/30 p-4">
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 id={`section-${section.id}`} className="text-xl font-semibold">{section.title}</h3>
+                {content.canManage && <Badge variant="outline">{section.visibility}</Badge>}
+              </div>
+              {section.summary && <p className="mt-1 text-sm text-muted-foreground">{section.summary}</p>}
+            </div>
+            {canEdit && (
+              <div className="flex shrink-0 items-center gap-1">
+                <Button variant="ghost" size="icon-sm" aria-label={`Move ${section.title} section up`} disabled={sectionIndex === 0 || reorderSections.isPending} onClick={() => moveSection(sectionIndex, -1)}><ArrowUp /></Button>
+                <Button variant="ghost" size="icon-sm" aria-label={`Move ${section.title} section down`} disabled={sectionIndex === content.sections.length - 1 || reorderSections.isPending} onClick={() => moveSection(sectionIndex, 1)}><ArrowDown /></Button>
+                <Button variant="ghost" size="icon-sm" aria-label={`Edit ${section.title} section`} onClick={() => { setEditingSection(section); setSectionDialogOpen(true) }}><Pencil /></Button>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={`Delete ${section.title} section`}
+                  onClick={() => {
+                    if (window.confirm(`Delete “${section.title}” and all content inside it?`)) deleteSection.mutate(section.id)
+                  }}
+                ><Trash2 /></Button>
+              </div>
+            )}
+          </div>
+          <div className="divide-y">
+            {section.items.map((item, itemIndex) => (
+              <div key={item.id} className="flex items-start gap-3 p-4">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-start gap-2">
+                    <div className="min-w-0 flex-1"><ContentItemView item={item} artifacts={artifacts} /></div>
+                    {content.canManage && (
+                      <div className="flex gap-1">
+                        <Badge variant="secondary">{item.kind}</Badge>
+                        <Badge variant="outline">{item.visibility}</Badge>
+                      </div>
+                    )}
+                  </div>
+                </div>
+                {canEdit && (
+                  <div className="flex shrink-0 items-center gap-1">
+                    <Button variant="ghost" size="icon-sm" aria-label={`Move ${item.title} up`} disabled={itemIndex === 0 || reorderItems.isPending} onClick={() => moveItem(section, itemIndex, -1)}><ArrowUp /></Button>
+                    <Button variant="ghost" size="icon-sm" aria-label={`Move ${item.title} down`} disabled={itemIndex === section.items.length - 1 || reorderItems.isPending} onClick={() => moveItem(section, itemIndex, 1)}><ArrowDown /></Button>
+                    <Button variant="ghost" size="icon-sm" aria-label={`Edit ${item.title}`} onClick={() => openEditItem(item)}><Pencil /></Button>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label={`Delete ${item.title}`}
+                      onClick={() => {
+                        if (window.confirm(`Delete “${item.title}”?`)) deleteItem.mutate(item.id)
+                      }}
+                    ><Trash2 /></Button>
+                  </div>
+                )}
+              </div>
+            ))}
+            {section.items.length === 0 && (
+              <div className="p-6 text-center text-sm text-muted-foreground">No content in this section.</div>
+            )}
+          </div>
+          {canEdit && (
+            <div className="border-t p-3">
+              <Button variant="outline" size="sm" onClick={() => openNewItem(section.id)}><Plus /> Add content</Button>
+            </div>
+          )}
+        </section>
+      ))}
+
+      {content.sections.length === 0 && (
+        <div className="rounded-lg border p-8 text-center text-muted-foreground">
+          {canEdit ? 'Add the first section to build this course outline.' : 'No course content has been published yet.'}
+        </div>
+      )}
+
+      {canManage && (
+        <>
+          <SectionDialog
+            section={editingSection}
+            open={sectionDialogOpen}
+            onOpenChange={setSectionDialogOpen}
+            onSubmit={saveSection}
+            pending={createSection.isPending || updateSection.isPending}
+          />
+          <ItemDialog
+            item={editingItem}
+            assignments={assignments}
+            artifacts={artifacts}
+            open={itemDialogOpen}
+            onOpenChange={setItemDialogOpen}
+            onSubmit={saveItem}
+            pending={createItem.isPending || updateItem.isPending}
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend-dev/src/app/courses/tabs/content/item-dialog.tsx
+++ b/frontend-dev/src/app/courses/tabs/content/item-dialog.tsx
@@ -1,0 +1,193 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { LmsArtifact } from '@/hooks/use-artifacts'
+import { Assignment } from '@/hooks/use-assignments'
+import {
+  CourseContentVisibility,
+  CourseItem,
+  CourseItemKind,
+  CreateItemInput,
+} from '@/hooks/use-course-content'
+
+
+export function ItemDialog({
+  item,
+  assignments,
+  artifacts,
+  open,
+  onOpenChange,
+  onSubmit,
+  pending,
+}: {
+  item?: CourseItem | null
+  assignments: Assignment[]
+  artifacts: LmsArtifact[]
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (data: CreateItemInput) => Promise<void>
+  pending: boolean
+}) {
+  const [title, setTitle] = useState('')
+  const [kind, setKind] = useState<CourseItemKind>('page')
+  const [visibility, setVisibility] = useState<CourseContentVisibility>('draft')
+  const [body, setBody] = useState('')
+  const [url, setUrl] = useState('')
+  const [resourceId, setResourceId] = useState('')
+
+  useEffect(() => {
+    if (!open) return
+    setTitle(item?.title ?? '')
+    setKind(item?.kind ?? 'page')
+    setVisibility(item?.visibility ?? 'draft')
+    setBody(typeof item?.payload.body === 'string' ? item.payload.body : '')
+    setUrl(typeof item?.payload.url === 'string' ? item.payload.url : '')
+    setResourceId(item?.resourceId ?? '')
+  }, [open, item])
+
+  const valid = useMemo(() => {
+    if (!title.trim()) return false
+    if (kind === 'page') return Boolean(body.trim())
+    if (kind === 'link') return /^https?:\/\//i.test(url.trim())
+    if (kind === 'file' || kind === 'assignment') return Boolean(resourceId)
+    return true
+  }, [body, kind, resourceId, title, url])
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!valid) return
+    const payload = kind === 'page'
+      ? { body: body.trim() }
+      : kind === 'link'
+        ? { url: url.trim() }
+        : {}
+    await onSubmit({
+      title: title.trim(),
+      kind,
+      visibility,
+      resourceId: resourceId || null,
+      payload,
+    })
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto" aria-describedby="item-dialog-description">
+        <form className="space-y-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{item ? 'Edit content item' : 'Add content item'}</DialogTitle>
+            <DialogDescription id="item-dialog-description">
+              Add instructions or link an existing course resource. Resource type cannot be changed after creation.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="item-kind">Type</Label>
+            <select
+              id="item-kind"
+              className="h-9 w-full rounded-md border bg-background px-3 text-sm disabled:opacity-60"
+              value={kind}
+              disabled={Boolean(item)}
+              onChange={(event) => {
+                setKind(event.target.value as CourseItemKind)
+                setResourceId('')
+              }}
+            >
+              <option value="heading">Heading</option>
+              <option value="page">Page</option>
+              <option value="link">Link</option>
+              <option value="file">Existing file</option>
+              <option value="assignment">Existing assignment</option>
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="item-title">Title</Label>
+            <Input id="item-title" value={title} onChange={(event) => setTitle(event.target.value)} autoFocus />
+          </div>
+          {kind === 'page' && (
+            <div className="space-y-2">
+              <Label htmlFor="item-body">Page content</Label>
+              <Textarea id="item-body" className="min-h-36" value={body} onChange={(event) => setBody(event.target.value)} />
+            </div>
+          )}
+          {kind === 'link' && (
+            <div className="space-y-2">
+              <Label htmlFor="item-url">URL</Label>
+              <Input id="item-url" type="url" placeholder="https://example.edu" value={url} onChange={(event) => setUrl(event.target.value)} />
+            </div>
+          )}
+          {kind === 'assignment' && (
+            <div className="space-y-2">
+              <Label htmlFor="item-assignment">Assignment</Label>
+              <select
+                id="item-assignment"
+                className="h-9 w-full rounded-md border bg-background px-3 text-sm disabled:opacity-60"
+                value={resourceId}
+                disabled={Boolean(item)}
+                onChange={(event) => {
+                  const id = event.target.value
+                  setResourceId(id)
+                  const assignment = assignments.find((candidate) => candidate.id === id)
+                  if (assignment && !title.trim()) setTitle(assignment.title)
+                }}
+              >
+                <option value="">Choose an assignment</option>
+                {assignments.map((assignment) => <option key={assignment.id} value={assignment.id}>{assignment.title}</option>)}
+              </select>
+            </div>
+          )}
+          {kind === 'file' && (
+            <div className="space-y-2">
+              <Label htmlFor="item-file">File</Label>
+              <select
+                id="item-file"
+                className="h-9 w-full rounded-md border bg-background px-3 text-sm disabled:opacity-60"
+                value={resourceId}
+                disabled={Boolean(item)}
+                onChange={(event) => {
+                  const id = event.target.value
+                  setResourceId(id)
+                  const artifact = artifacts.find((candidate) => candidate.id === id)
+                  if (artifact && !title.trim()) setTitle(artifact.title)
+                }}
+              >
+                <option value="">Choose a course-visible file</option>
+                {artifacts
+                  .filter((artifact) => ['course', 'public'].includes(artifact.accessLevel) && artifact.status !== 'archived')
+                  .map((artifact) => <option key={artifact.id} value={artifact.id}>{artifact.title}</option>)}
+              </select>
+            </div>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="item-visibility">Visibility</Label>
+            <select
+              id="item-visibility"
+              className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+              value={visibility}
+              onChange={(event) => setVisibility(event.target.value as CourseContentVisibility)}
+            >
+              <option value="draft">Draft</option>
+              <option value="published">Published</option>
+              <option value="hidden">Hidden</option>
+            </select>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+            <Button type="submit" disabled={!valid || pending}>{pending ? 'Saving…' : 'Save item'}</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend-dev/src/app/courses/tabs/content/section-dialog.tsx
+++ b/frontend-dev/src/app/courses/tabs/content/section-dialog.tsx
@@ -1,0 +1,94 @@
+import { FormEvent, useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  CourseContentVisibility,
+  CourseSection,
+  CreateSectionInput,
+} from '@/hooks/use-course-content'
+
+
+export function SectionDialog({
+  section,
+  open,
+  onOpenChange,
+  onSubmit,
+  pending,
+}: {
+  section?: CourseSection | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (data: CreateSectionInput) => Promise<void>
+  pending: boolean
+}) {
+  const [title, setTitle] = useState('')
+  const [summary, setSummary] = useState('')
+  const [visibility, setVisibility] = useState<CourseContentVisibility>('draft')
+
+  useEffect(() => {
+    if (!open) return
+    setTitle(section?.title ?? '')
+    setSummary(section?.summary ?? '')
+    setVisibility(section?.visibility ?? 'draft')
+  }, [open, section])
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!title.trim()) return
+    await onSubmit({ title: title.trim(), summary: summary.trim() || null, visibility })
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent aria-describedby="section-dialog-description">
+        <form className="space-y-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{section ? 'Edit section' : 'Add section'}</DialogTitle>
+            <DialogDescription id="section-dialog-description">
+              Sections organize the course outline. Draft and hidden sections are staff-only.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="section-title">Title</Label>
+            <Input id="section-title" value={title} onChange={(event) => setTitle(event.target.value)} autoFocus />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="section-summary">Summary</Label>
+            <Textarea id="section-summary" value={summary} onChange={(event) => setSummary(event.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="section-visibility">Visibility</Label>
+            <select
+              id="section-visibility"
+              className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+              value={visibility}
+              onChange={(event) => setVisibility(event.target.value as CourseContentVisibility)}
+            >
+              <option value="draft">Draft</option>
+              <option value="published">Published</option>
+              <option value="hidden">Hidden</option>
+            </select>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+            <Button type="submit" disabled={!title.trim() || pending}>
+              {pending ? 'Saving…' : 'Save section'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend-dev/src/components/artifact-action.tsx
+++ b/frontend-dev/src/components/artifact-action.tsx
@@ -18,7 +18,7 @@ import { PdfPreview } from "@/components/pdf-preview";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 type ArtifactActionProps = Omit<ComponentProps<typeof Button>, "onClick"> & {
-  artifact: LmsArtifact;
+  artifact: Pick<LmsArtifact, "id" | "title" | "mime">;
   icon?: ComponentType<{ className?: string; size?: number }>;
   label?: ReactNode;
 };

--- a/frontend-dev/src/hooks/use-course-content.ts
+++ b/frontend-dev/src/hooks/use-course-content.ts
@@ -1,0 +1,182 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import api from '@/lib/api'
+
+
+export type CourseContentVisibility = 'draft' | 'published' | 'hidden'
+export type CourseItemKind = 'heading' | 'page' | 'link' | 'file' | 'assignment'
+
+export type CourseItem = {
+  id: string
+  courseId: string
+  sectionId: string
+  title: string
+  position: number
+  kind: CourseItemKind
+  visibility: CourseContentVisibility
+  resourceType?: string | null
+  resourceId?: string | null
+  payloadSchemaUri?: string | null
+  payload: Record<string, unknown>
+  createdAt: string
+  updatedAt: string
+}
+
+export type CourseSection = {
+  id: string
+  courseId: string
+  title: string
+  summary?: string | null
+  position: number
+  visibility: CourseContentVisibility
+  createdAt: string
+  updatedAt: string
+  items: CourseItem[]
+}
+
+export type CourseContent = {
+  courseId: string
+  canManage: boolean
+  sections: CourseSection[]
+}
+
+export type CreateSectionInput = {
+  title: string
+  summary?: string | null
+  visibility: CourseContentVisibility
+}
+
+export type UpdateSectionInput = Partial<CreateSectionInput>
+
+export type CreateItemInput = {
+  title: string
+  kind: CourseItemKind
+  visibility: CourseContentVisibility
+  resourceId?: string | null
+  payload?: Record<string, unknown>
+}
+
+export type UpdateItemInput = Partial<Pick<CreateItemInput, 'title' | 'visibility' | 'payload'>>
+
+export const courseContentKeys = {
+  all: ['course-content'] as const,
+  course: (courseId: string) => [...courseContentKeys.all, courseId] as const,
+}
+
+async function fetchCourseContent(courseId: string): Promise<CourseContent> {
+  return (await api.get(`/lms/courses/${courseId}/content`)).data
+}
+
+function useInvalidateCourseContent(courseId: string) {
+  const queryClient = useQueryClient()
+  return () => queryClient.invalidateQueries({ queryKey: courseContentKeys.course(courseId) })
+}
+
+export function useCourseContent(courseId?: string) {
+  return useQuery({
+    queryKey: courseContentKeys.course(courseId ?? 'unknown'),
+    queryFn: () => fetchCourseContent(courseId as string),
+    enabled: Boolean(courseId),
+  })
+}
+
+export function useCreateCourseSection(courseId: string) {
+  const invalidate = useInvalidateCourseContent(courseId)
+  return useMutation({
+    mutationFn: async (data: CreateSectionInput): Promise<CourseSection> =>
+      (await api.post(`/lms/courses/${courseId}/sections`, data)).data,
+    onSuccess: () => {
+      invalidate()
+      toast.success('Section created')
+    },
+    onError: (error: Error) => toast.error('Failed to create section', { description: error.message }),
+  })
+}
+
+export function useUpdateCourseSection(courseId: string) {
+  const invalidate = useInvalidateCourseContent(courseId)
+  return useMutation({
+    mutationFn: async ({ id, data }: { id: string; data: UpdateSectionInput }): Promise<CourseSection> =>
+      (await api.patch(`/lms/courses/${courseId}/sections/${id}`, data)).data,
+    onSuccess: () => {
+      invalidate()
+      toast.success('Section updated')
+    },
+    onError: (error: Error) => toast.error('Failed to update section', { description: error.message }),
+  })
+}
+
+export function useDeleteCourseSection(courseId: string) {
+  const invalidate = useInvalidateCourseContent(courseId)
+  return useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      await api.delete(`/lms/courses/${courseId}/sections/${id}`)
+    },
+    onSuccess: () => {
+      invalidate()
+      toast.success('Section deleted')
+    },
+    onError: (error: Error) => toast.error('Failed to delete section', { description: error.message }),
+  })
+}
+
+export function useReorderCourseSections(courseId: string) {
+  const invalidate = useInvalidateCourseContent(courseId)
+  return useMutation({
+    mutationFn: async (orderedIds: string[]): Promise<CourseSection[]> =>
+      (await api.put(`/lms/courses/${courseId}/sections/order`, { orderedIds })).data,
+    onSuccess: invalidate,
+    onError: (error: Error) => toast.error('Failed to reorder sections', { description: error.message }),
+  })
+}
+
+export function useCreateCourseItem(courseId: string) {
+  const invalidate = useInvalidateCourseContent(courseId)
+  return useMutation({
+    mutationFn: async ({ sectionId, data }: { sectionId: string; data: CreateItemInput }): Promise<CourseItem> =>
+      (await api.post(`/lms/courses/${courseId}/sections/${sectionId}/items`, data)).data,
+    onSuccess: () => {
+      invalidate()
+      toast.success('Content item created')
+    },
+    onError: (error: Error) => toast.error('Failed to create content item', { description: error.message }),
+  })
+}
+
+export function useUpdateCourseItem(courseId: string) {
+  const invalidate = useInvalidateCourseContent(courseId)
+  return useMutation({
+    mutationFn: async ({ id, data }: { id: string; data: UpdateItemInput }): Promise<CourseItem> =>
+      (await api.patch(`/lms/courses/${courseId}/items/${id}`, data)).data,
+    onSuccess: () => {
+      invalidate()
+      toast.success('Content item updated')
+    },
+    onError: (error: Error) => toast.error('Failed to update content item', { description: error.message }),
+  })
+}
+
+export function useDeleteCourseItem(courseId: string) {
+  const invalidate = useInvalidateCourseContent(courseId)
+  return useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      await api.delete(`/lms/courses/${courseId}/items/${id}`)
+    },
+    onSuccess: () => {
+      invalidate()
+      toast.success('Content item deleted')
+    },
+    onError: (error: Error) => toast.error('Failed to delete content item', { description: error.message }),
+  })
+}
+
+export function useReorderCourseItems(courseId: string) {
+  const invalidate = useInvalidateCourseContent(courseId)
+  return useMutation({
+    mutationFn: async ({ sectionId, orderedIds }: { sectionId: string; orderedIds: string[] }): Promise<CourseItem[]> =>
+      (await api.put(`/lms/courses/${courseId}/sections/${sectionId}/items/order`, { orderedIds })).data,
+    onSuccess: invalidate,
+    onError: (error: Error) => toast.error('Failed to reorder content items', { description: error.message }),
+  })
+}

--- a/src/fair_platform/backend/alembic/versions/20260812_0030_course_content_backfill.py
+++ b/src/fair_platform/backend/alembic/versions/20260812_0030_course_content_backfill.py
@@ -1,0 +1,200 @@
+"""Backfill a default content outline for existing courses.
+
+Revision ID: 20260812_0030
+Revises: 20260812_0029
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4, uuid5
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260812_0030"
+down_revision: str = "20260812_0029"
+branch_labels = None
+depends_on = None
+
+
+BACKFILL_SCHEMA_URI = "urn:fair:lms:course-item:assignment-backfill:v1"
+DEFAULT_SECTION_TITLE = "Course content"
+DEFAULT_SECTION_SUMMARY = "Assignments already available in this course."
+BACKFILL_SECTION_NAMESPACE = UUID("5d3412f8-9294-5de9-9b8f-87f4b1218e4a")
+
+
+def _backfill_section_id(course_id: object) -> UUID:
+    canonical_course_id = (
+        course_id if isinstance(course_id, UUID) else UUID(str(course_id))
+    )
+    return uuid5(BACKFILL_SECTION_NAMESPACE, canonical_course_id.hex)
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    now = datetime.now(timezone.utc)
+    courses = sa.table("courses", sa.column("id", sa.UUID()))
+    assignments = sa.table(
+        "assignments",
+        sa.column("id", sa.UUID()),
+        sa.column("course_id", sa.UUID()),
+        sa.column("title", sa.String()),
+        sa.column("status", sa.String()),
+    )
+    sections = sa.table(
+        "course_sections",
+        sa.column("id", sa.UUID()),
+        sa.column("course_id", sa.UUID()),
+        sa.column("title", sa.String()),
+        sa.column("summary", sa.Text()),
+        sa.column("position", sa.Integer()),
+        sa.column("visibility", sa.String()),
+        sa.column("copied_from_id", sa.UUID()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+    items = sa.table(
+        "course_items",
+        sa.column("id", sa.UUID()),
+        sa.column("course_id", sa.UUID()),
+        sa.column("section_id", sa.UUID()),
+        sa.column("title", sa.String()),
+        sa.column("position", sa.Integer()),
+        sa.column("kind", sa.String()),
+        sa.column("visibility", sa.String()),
+        sa.column("resource_type", sa.String()),
+        sa.column("resource_id", sa.UUID()),
+        sa.column("copied_from_id", sa.UUID()),
+        sa.column("payload_schema_uri", sa.String()),
+        sa.column("payload", sa.JSON()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+
+    for course_id in connection.execute(
+        sa.select(courses.c.id).order_by(courses.c.id)
+    ).scalars():
+        existing_resource_ids = set(
+            connection.execute(
+                sa.select(items.c.resource_id).where(
+                    items.c.course_id == course_id,
+                    items.c.resource_type == "assignment",
+                    items.c.resource_id.is_not(None),
+                )
+            ).scalars()
+        )
+        course_assignments = list(
+            connection.execute(
+                sa.select(
+                    assignments.c.id,
+                    assignments.c.title,
+                    assignments.c.status,
+                )
+                .where(assignments.c.course_id == course_id)
+                .order_by(assignments.c.title, assignments.c.id)
+            ).mappings()
+        )
+        missing_assignments = [
+            assignment
+            for assignment in course_assignments
+            if assignment["id"] not in existing_resource_ids
+        ]
+        if not missing_assignments:
+            continue
+
+        section_id = _backfill_section_id(course_id)
+        existing_sections = list(
+            connection.execute(
+                sa.select(sections.c.id, sections.c.position).where(
+                    sections.c.course_id == course_id
+                )
+            ).mappings()
+        )
+        if not any(section["id"] == section_id for section in existing_sections):
+            section_position = (
+                max(
+                    (int(section["position"]) for section in existing_sections),
+                    default=-1,
+                )
+                + 1
+            )
+            connection.execute(
+                sections.insert().values(
+                    id=section_id,
+                    course_id=course_id,
+                    title=DEFAULT_SECTION_TITLE,
+                    summary=DEFAULT_SECTION_SUMMARY,
+                    position=section_position,
+                    visibility="published",
+                    copied_from_id=None,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        maximum_item_position = connection.execute(
+            sa.select(sa.func.max(items.c.position)).where(
+                items.c.section_id == section_id
+            )
+        ).scalar()
+        next_item_position = (
+            int(maximum_item_position) + 1 if maximum_item_position is not None else 0
+        )
+        for offset, assignment in enumerate(missing_assignments):
+            connection.execute(
+                items.insert().values(
+                    id=uuid4(),
+                    course_id=course_id,
+                    section_id=section_id,
+                    title=assignment["title"],
+                    position=next_item_position + offset,
+                    kind="assignment",
+                    visibility=(
+                        "published" if assignment["status"] == "published" else "draft"
+                    ),
+                    resource_type="assignment",
+                    resource_id=assignment["id"],
+                    copied_from_id=None,
+                    payload_schema_uri=BACKFILL_SCHEMA_URI,
+                    payload={},
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    courses = sa.table("courses", sa.column("id", sa.UUID()))
+    items = sa.table(
+        "course_items",
+        sa.column("id", sa.UUID()),
+        sa.column("section_id", sa.UUID()),
+        sa.column("payload_schema_uri", sa.String()),
+    )
+    sections = sa.table(
+        "course_sections",
+        sa.column("id", sa.UUID()),
+    )
+    backfill_section_ids = set(
+        connection.execute(
+            sa.select(items.c.section_id).where(
+                items.c.payload_schema_uri == BACKFILL_SCHEMA_URI
+            )
+        ).scalars()
+    )
+    backfill_section_ids.update(
+        _backfill_section_id(course_id)
+        for course_id in connection.execute(sa.select(courses.c.id)).scalars()
+    )
+    connection.execute(
+        items.delete().where(items.c.payload_schema_uri == BACKFILL_SCHEMA_URI)
+    )
+    for section_id in backfill_section_ids:
+        has_remaining_items = connection.execute(
+            sa.select(items.c.id).where(items.c.section_id == section_id).limit(1)
+        ).first()
+        if has_remaining_items is not None:
+            continue
+        connection.execute(sections.delete().where(sections.c.id == section_id))

--- a/src/fair_platform/backend/api/routers/assignments.py
+++ b/src/fair_platform/backend/api/routers/assignments.py
@@ -32,6 +32,7 @@ from fair_platform.backend.data.models.enrollment import (
 )
 from fair_platform.backend.services.artifact_manager import get_artifact_manager
 from fair_platform.backend.services.course_access import can_manage_course
+from fair_platform.backend.services.course_content_service import CourseContentService
 from fair_platform.backend.services.notifications import notify_course_members
 
 router = APIRouter()
@@ -309,18 +310,23 @@ def delete_assignment(
             detail="Only the course instructor or admin can delete this assignment",
         )
 
-    submissions = (
-        db.query(Submission)
-        .filter(Submission.assignment_id == assignment_id)
-        .all()
-    )
-    for submission in submissions:
-        submission.artifacts.clear()
-        submission.runs.clear()
-        db.delete(submission)
+    try:
+        CourseContentService(db).remove_resource_links("assignment", assignment_id)
+        submissions = (
+            db.query(Submission)
+            .filter(Submission.assignment_id == assignment_id)
+            .all()
+        )
+        for submission in submissions:
+            submission.artifacts.clear()
+            submission.runs.clear()
+            db.delete(submission)
 
-    db.delete(assignment)
-    db.commit()
+        db.delete(assignment)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
     return None
 
 

--- a/src/fair_platform/backend/api/routers/course_content.py
+++ b/src/fair_platform/backend/api/routers/course_content.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from fair_platform.backend.api.routers.auth import get_current_user
+from fair_platform.backend.api.schema.course_content import (
+    CourseContentRead,
+    CourseItemCreate,
+    CourseItemRead,
+    CourseItemUpdate,
+    CourseSectionCreate,
+    CourseSectionRead,
+    CourseSectionUpdate,
+    ExactOrderUpdate,
+)
+from fair_platform.backend.data.database import session_dependency
+from fair_platform.backend.data.models.course import Course
+from fair_platform.backend.data.models.lms_content import CourseItem, CourseSection
+from fair_platform.backend.data.models.user import User
+from fair_platform.backend.services.course_access import can_manage_course, can_view_course
+from fair_platform.backend.services.course_content_service import (
+    CourseContentConflict,
+    CourseContentError,
+    CourseContentNotFound,
+    CourseContentService,
+)
+
+
+router = APIRouter()
+
+
+def _course(db: Session, course_id: UUID, user: User, *, manage: bool) -> Course:
+    course = db.get(Course, course_id)
+    if course is None:
+        raise HTTPException(status_code=404, detail="Course not found")
+    allowed = (
+        can_manage_course(db, course, user)
+        if manage
+        else can_view_course(db, course, user)
+    )
+    if not allowed:
+        detail = (
+            "Only course staff can manage course content"
+            if manage
+            else "Only active course members can view course content"
+        )
+        raise HTTPException(status_code=403, detail=detail)
+    if manage and course.is_archived:
+        raise HTTPException(status_code=409, detail="Archived courses are read-only")
+    return course
+
+
+def _item_read(item: CourseItem) -> CourseItemRead:
+    return CourseItemRead.model_validate(item)
+
+
+def _section_read(
+    section: CourseSection, items: list[CourseItem] | None = None
+) -> CourseSectionRead:
+    return CourseSectionRead(
+        id=section.id,
+        course_id=section.course_id,
+        title=section.title,
+        summary=section.summary,
+        position=section.position,
+        visibility=section.visibility,
+        created_at=section.created_at,
+        updated_at=section.updated_at,
+        items=[_item_read(item) for item in (items if items is not None else section.items)],
+    )
+
+
+def _raise_service_error(db: Session, error: Exception) -> None:
+    db.rollback()
+    if isinstance(error, CourseContentNotFound):
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    if isinstance(error, CourseContentConflict):
+        raise HTTPException(status_code=409, detail=str(error)) from error
+    if isinstance(error, IntegrityError):
+        raise HTTPException(
+            status_code=409, detail="Course content changed; refresh and try again"
+        ) from error
+    if isinstance(error, CourseContentError):
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    raise error
+
+
+@router.get("/courses/{course_id}/content", response_model=CourseContentRead)
+def get_course_content(
+    course_id: UUID,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+) -> CourseContentRead:
+    course = _course(db, course_id, current_user, manage=False)
+    can_manage = can_manage_course(db, course, current_user)
+    sections = CourseContentService(db).list_sections(
+        course_id, staff_view=can_manage
+    )
+    return CourseContentRead(
+        course_id=course_id,
+        can_manage=can_manage,
+        sections=[_section_read(section, items) for section, items in sections],
+    )
+
+
+@router.post(
+    "/courses/{course_id}/sections",
+    response_model=CourseSectionRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_course_section(
+    course_id: UUID,
+    payload: CourseSectionCreate,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+) -> CourseSectionRead:
+    _course(db, course_id, current_user, manage=True)
+    try:
+        section = CourseContentService(db).create_section(
+            course_id,
+            title=payload.title,
+            summary=payload.summary,
+            visibility=payload.visibility,
+        )
+        db.commit()
+        return _section_read(section, [])
+    except (CourseContentError, IntegrityError) as error:
+        _raise_service_error(db, error)
+
+
+@router.patch(
+    "/courses/{course_id}/sections/{section_id}",
+    response_model=CourseSectionRead,
+)
+def update_course_section(
+    course_id: UUID,
+    section_id: UUID,
+    payload: CourseSectionUpdate,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+) -> CourseSectionRead:
+    _course(db, course_id, current_user, manage=True)
+    try:
+        section = CourseContentService(db).update_section(
+            course_id,
+            section_id,
+            payload.model_dump(exclude_unset=True),
+        )
+        db.commit()
+        db.refresh(section)
+        return _section_read(section)
+    except (CourseContentError, IntegrityError) as error:
+        _raise_service_error(db, error)
+
+
+@router.delete(
+    "/courses/{course_id}/sections/{section_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_course_section(
+    course_id: UUID,
+    section_id: UUID,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    _course(db, course_id, current_user, manage=True)
+    try:
+        CourseContentService(db).delete_section(course_id, section_id)
+        db.commit()
+    except (CourseContentError, IntegrityError) as error:
+        _raise_service_error(db, error)
+
+
+@router.put(
+    "/courses/{course_id}/sections/order",
+    response_model=list[CourseSectionRead],
+)
+def reorder_course_sections(
+    course_id: UUID,
+    payload: ExactOrderUpdate,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+) -> list[CourseSectionRead]:
+    _course(db, course_id, current_user, manage=True)
+    try:
+        sections = CourseContentService(db).reorder_sections(
+            course_id, payload.ordered_ids
+        )
+        db.commit()
+        return [_section_read(section) for section in sections]
+    except (CourseContentError, IntegrityError) as error:
+        _raise_service_error(db, error)
+
+
+@router.post(
+    "/courses/{course_id}/sections/{section_id}/items",
+    response_model=CourseItemRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_course_item(
+    course_id: UUID,
+    section_id: UUID,
+    payload: CourseItemCreate,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+) -> CourseItemRead:
+    _course(db, course_id, current_user, manage=True)
+    try:
+        item = CourseContentService(db).create_item(
+            course_id,
+            section_id,
+            title=payload.title,
+            kind=payload.kind,
+            visibility=payload.visibility,
+            resource_id=payload.resource_id,
+            payload=payload.payload,
+        )
+        db.commit()
+        return _item_read(item)
+    except (CourseContentError, IntegrityError) as error:
+        _raise_service_error(db, error)
+
+
+@router.patch(
+    "/courses/{course_id}/items/{item_id}", response_model=CourseItemRead
+)
+def update_course_item(
+    course_id: UUID,
+    item_id: UUID,
+    payload: CourseItemUpdate,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+) -> CourseItemRead:
+    _course(db, course_id, current_user, manage=True)
+    try:
+        item = CourseContentService(db).update_item(
+            course_id,
+            item_id,
+            payload.model_dump(exclude_unset=True),
+        )
+        db.commit()
+        return _item_read(item)
+    except (CourseContentError, IntegrityError) as error:
+        _raise_service_error(db, error)
+
+
+@router.delete(
+    "/courses/{course_id}/items/{item_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_course_item(
+    course_id: UUID,
+    item_id: UUID,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    _course(db, course_id, current_user, manage=True)
+    try:
+        CourseContentService(db).delete_item(course_id, item_id)
+        db.commit()
+    except (CourseContentError, IntegrityError) as error:
+        _raise_service_error(db, error)
+
+
+@router.put(
+    "/courses/{course_id}/sections/{section_id}/items/order",
+    response_model=list[CourseItemRead],
+)
+def reorder_course_items(
+    course_id: UUID,
+    section_id: UUID,
+    payload: ExactOrderUpdate,
+    db: Session = Depends(session_dependency),
+    current_user: User = Depends(get_current_user),
+) -> list[CourseItemRead]:
+    _course(db, course_id, current_user, manage=True)
+    try:
+        items = CourseContentService(db).reorder_items(
+            course_id, section_id, payload.ordered_ids
+        )
+        db.commit()
+        return [_item_read(item) for item in items]
+    except (CourseContentError, IntegrityError) as error:
+        _raise_service_error(db, error)
+
+
+__all__ = ["router"]

--- a/src/fair_platform/backend/api/schema/course_content.py
+++ b/src/fair_platform/backend/api/schema/course_content.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from fair_platform.backend.api.schema.utils import schema_config
+from fair_platform.backend.data.models.lms_content import CourseContentVisibility
+
+
+CourseItemKind = Literal["heading", "page", "link", "file", "assignment"]
+
+
+class CourseSectionCreate(BaseModel):
+    model_config = schema_config
+
+    title: str = Field(min_length=1, max_length=255)
+    summary: str | None = None
+    visibility: CourseContentVisibility = CourseContentVisibility.draft
+
+
+class CourseSectionUpdate(BaseModel):
+    model_config = schema_config
+
+    title: str | None = Field(default=None, min_length=1, max_length=255)
+    summary: str | None = None
+    visibility: CourseContentVisibility | None = None
+
+
+class CourseItemCreate(BaseModel):
+    model_config = schema_config
+
+    title: str = Field(min_length=1, max_length=255)
+    kind: CourseItemKind
+    visibility: CourseContentVisibility = CourseContentVisibility.draft
+    resource_id: UUID | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class CourseItemUpdate(BaseModel):
+    model_config = schema_config
+
+    title: str | None = Field(default=None, min_length=1, max_length=255)
+    visibility: CourseContentVisibility | None = None
+    payload: dict[str, Any] | None = None
+
+
+class ExactOrderUpdate(BaseModel):
+    model_config = schema_config
+
+    ordered_ids: list[UUID]
+
+
+class CourseItemRead(BaseModel):
+    model_config = schema_config
+
+    id: UUID
+    course_id: UUID
+    section_id: UUID
+    title: str
+    position: int
+    kind: CourseItemKind
+    visibility: CourseContentVisibility
+    resource_type: str | None = None
+    resource_id: UUID | None = None
+    payload_schema_uri: str | None = None
+    payload: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+
+
+class CourseSectionRead(BaseModel):
+    model_config = schema_config
+
+    id: UUID
+    course_id: UUID
+    title: str
+    summary: str | None = None
+    position: int
+    visibility: CourseContentVisibility
+    created_at: datetime
+    updated_at: datetime
+    items: list[CourseItemRead]
+
+
+class CourseContentRead(BaseModel):
+    model_config = schema_config
+
+    course_id: UUID
+    can_manage: bool
+    sections: list[CourseSectionRead]
+
+
+__all__ = [
+    "CourseContentRead",
+    "CourseItemCreate",
+    "CourseItemKind",
+    "CourseItemRead",
+    "CourseItemUpdate",
+    "CourseSectionCreate",
+    "CourseSectionRead",
+    "CourseSectionUpdate",
+    "ExactOrderUpdate",
+]

--- a/src/fair_platform/backend/main.py
+++ b/src/fair_platform/backend/main.py
@@ -26,6 +26,9 @@ from fair_platform.backend.api.routers.executions import router as executions_ro
 from fair_platform.backend.api.routers.artifacts import router as artifacts_router
 from fair_platform.backend.api.routers.flows import router as flows_router
 from fair_platform.backend.api.routers.lms import router as lms_router
+from fair_platform.backend.api.routers.course_content import (
+    router as course_content_router,
+)
 from fair_platform.backend.services.execution_outbox_dispatcher import (
     ExecutionOutboxDispatcher,
 )
@@ -119,6 +122,9 @@ app.include_router(version_router, prefix="/api", tags=["version"])
 app.include_router(rubrics_router, prefix="/api/rubrics", tags=["rubrics"])
 app.include_router(enrollments_router, prefix="/api/enrollments", tags=["enrollments"])
 app.include_router(lms_router, prefix="/api/lms", tags=["lms"])
+app.include_router(
+    course_content_router, prefix="/api/lms", tags=["course-content"]
+)
 app.include_router(system_router, prefix="/api/v1/system", tags=["system"])
 app.include_router(executions_router, prefix="/api/v1", tags=["executions"])
 app.include_router(artifacts_router, prefix="/api/v1", tags=["artifacts"])

--- a/src/fair_platform/backend/services/artifact_manager.py
+++ b/src/fair_platform/backend/services/artifact_manager.py
@@ -16,7 +16,7 @@ from fair_platform.backend.data.models.user import User
 from fair_platform.backend.data.models.course import Course
 from fair_platform.backend.data.models.assignment import Assignment
 from fair_platform.backend.data.models.submission import Submission
-from fair_platform.backend.data.models.enrollment import Enrollment
+from fair_platform.backend.data.models.enrollment import Enrollment, EnrollmentStatus
 from fair_platform.backend.storage.provider import (
     StorageProvider,
     get_storage_provider,
@@ -678,6 +678,7 @@ class ArtifactManager:
             enrollment = self.db.query(Enrollment).filter(
                 Enrollment.user_id == user.id,
                 Enrollment.course_id == artifact.course_id,
+                Enrollment.status == EnrollmentStatus.active,
             ).first()
             if enrollment:
                 return True

--- a/src/fair_platform/backend/services/artifact_manager.py
+++ b/src/fair_platform/backend/services/artifact_manager.py
@@ -27,6 +27,7 @@ from fair_platform.backend.core.security.permissions import (
     has_capability,
     has_capability_and_owner,
 )
+from fair_platform.backend.services.course_content_service import CourseContentService
 
 
 class ArtifactManager:
@@ -272,6 +273,10 @@ class ArtifactManager:
         if status is not None:
             self._validate_status_transition(artifact.status, status)
             artifact.status = status
+            if status == ArtifactStatus.archived:
+                CourseContentService(self.db).remove_resource_links(
+                    "artifact", artifact.id
+                )
         if course_id is not None:
             artifact.course_id = course_id
         if assignment_id is not None:
@@ -313,14 +318,17 @@ class ArtifactManager:
         
         if not self.can_delete(user, artifact):
             raise HTTPException(status_code=403, detail="Permission denied")
-        
+
         if hard_delete:
             if not has_capability(user, "cleanup_orphaned_artifacts"):
                 raise HTTPException(
                     status_code=403,
                     detail="Hard delete requires admin privileges"
                 )
-            
+
+        CourseContentService(self.db).remove_resource_links("artifact", artifact.id)
+
+        if hard_delete:
             for derivative in list(artifact.derivatives):
                 self._delete_derivative_object(derivative.storage_uri)
             
@@ -613,6 +621,9 @@ class ArtifactManager:
         
         count = 0
         for artifact in orphaned_artifacts:
+            CourseContentService(self.db).remove_resource_links(
+                "artifact", artifact.id
+            )
             if hard_delete:
                 for derivative in list(artifact.derivatives):
                     self._delete_derivative_object(derivative.storage_uri)

--- a/src/fair_platform/backend/services/course_content_service.py
+++ b/src/fair_platform/backend/services/course_content_service.py
@@ -243,6 +243,33 @@ class CourseContentService:
         self.db.flush()
         self._compact_items(section_id)
 
+    def remove_resource_links(self, resource_type: str, resource_id: UUID) -> int:
+        """Remove outline links to a deleted resource and repair item ordering."""
+        items = self.db.scalars(
+            select(CourseItem)
+            .where(
+                CourseItem.resource_type == resource_type,
+                CourseItem.resource_id == resource_id,
+            )
+            .with_for_update()
+        ).all()
+        item_ids = [item.id for item in items]
+        if item_ids:
+            copied_items = self.db.scalars(
+                select(CourseItem)
+                .where(CourseItem.copied_from_id.in_(item_ids))
+                .with_for_update()
+            ).all()
+            for copied_item in copied_items:
+                copied_item.copied_from_id = None
+        section_ids = {item.section_id for item in items}
+        for item in items:
+            self.db.delete(item)
+        self.db.flush()
+        for section_id in sorted(section_ids, key=str):
+            self._compact_items(section_id)
+        return len(items)
+
     def reorder_items(
         self, course_id: UUID, section_id: UUID, ordered_ids: list[UUID]
     ) -> list[CourseItem]:

--- a/src/fair_platform/backend/services/course_content_service.py
+++ b/src/fair_platform/backend/services/course_content_service.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlsplit
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, selectinload
+
+from fair_platform.backend.data.models.artifact import (
+    AccessLevel,
+    Artifact,
+    ArtifactStatus,
+)
+from fair_platform.backend.data.models.assignment import Assignment, AssignmentStatus
+from fair_platform.backend.data.models.lms_content import (
+    CourseContentVisibility,
+    CourseItem,
+    CourseSection,
+)
+
+
+COURSE_ITEM_KINDS = {"heading", "page", "link", "file", "assignment"}
+RESOURCE_TYPES = {"file": "artifact", "assignment": "assignment"}
+PAYLOAD_SCHEMAS = {
+    "heading": "urn:fair:lms:course-item:heading:v1",
+    "page": "urn:fair:lms:course-item:page:v1",
+    "link": "urn:fair:lms:course-item:link:v1",
+    "file": "urn:fair:lms:course-item:file:v1",
+    "assignment": "urn:fair:lms:course-item:assignment:v1",
+}
+
+
+class CourseContentError(ValueError):
+    pass
+
+
+class CourseContentNotFound(CourseContentError):
+    pass
+
+
+class CourseContentConflict(CourseContentError):
+    pass
+
+
+def _enum_value(value: object) -> str:
+    return value.value if hasattr(value, "value") else str(value)
+
+
+class CourseContentService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def list_sections(
+        self, course_id: UUID, *, staff_view: bool
+    ) -> list[tuple[CourseSection, list[CourseItem]]]:
+        sections = self.db.scalars(
+            select(CourseSection)
+            .where(CourseSection.course_id == course_id)
+            .options(selectinload(CourseSection.items))
+            .order_by(CourseSection.position, CourseSection.id)
+        ).all()
+
+        if staff_view:
+            return [
+                (section, sorted(section.items, key=lambda item: (item.position, item.id)))
+                for section in sections
+            ]
+
+        published_sections = [
+            section
+            for section in sections
+            if _enum_value(section.visibility) == CourseContentVisibility.published.value
+        ]
+        assignment_ids = {
+            item.resource_id
+            for section in published_sections
+            for item in section.items
+            if item.kind == "assignment" and item.resource_id is not None
+        }
+        published_assignments = set(
+            self.db.scalars(
+                select(Assignment.id).where(
+                    Assignment.id.in_(assignment_ids),
+                    Assignment.course_id == course_id,
+                    Assignment.status == AssignmentStatus.published,
+                )
+            ).all()
+            if assignment_ids
+            else []
+        )
+
+        result: list[tuple[CourseSection, list[CourseItem]]] = []
+        for section in published_sections:
+            visible_items = []
+            for item in sorted(section.items, key=lambda value: (value.position, value.id)):
+                if (
+                    _enum_value(item.visibility)
+                    != CourseContentVisibility.published.value
+                ):
+                    continue
+                if item.kind == "assignment" and item.resource_id not in published_assignments:
+                    continue
+                visible_items.append(item)
+            result.append((section, visible_items))
+        return result
+
+    def create_section(
+        self,
+        course_id: UUID,
+        *,
+        title: str,
+        summary: str | None,
+        visibility: CourseContentVisibility,
+    ) -> CourseSection:
+        position = self.db.scalar(
+            select(func.max(CourseSection.position)).where(
+                CourseSection.course_id == course_id
+            )
+        )
+        section = CourseSection(
+            course_id=course_id,
+            title=self._required_text(title, "Section title"),
+            summary=self._optional_text(summary),
+            position=(position + 1) if position is not None else 0,
+            visibility=visibility,
+        )
+        self.db.add(section)
+        self.db.flush()
+        return section
+
+    def update_section(
+        self, course_id: UUID, section_id: UUID, changes: dict[str, Any]
+    ) -> CourseSection:
+        section = self._section(course_id, section_id)
+        if "title" in changes:
+            section.title = self._required_text(changes["title"], "Section title")
+        if "summary" in changes:
+            section.summary = self._optional_text(changes["summary"])
+        if "visibility" in changes:
+            section.visibility = changes["visibility"]
+        self.db.flush()
+        return section
+
+    def delete_section(self, course_id: UUID, section_id: UUID) -> None:
+        section = self._section(course_id, section_id)
+        self.db.delete(section)
+        self.db.flush()
+        self._compact_sections(course_id)
+
+    def reorder_sections(
+        self, course_id: UUID, ordered_ids: list[UUID]
+    ) -> list[CourseSection]:
+        sections = self.db.scalars(
+            select(CourseSection)
+            .where(CourseSection.course_id == course_id)
+            .order_by(CourseSection.position)
+            .with_for_update()
+        ).all()
+        self._validate_exact_order(
+            ordered_ids,
+            [section.id for section in sections],
+            "section",
+        )
+        by_id = {section.id: section for section in sections}
+        ordered = [by_id[section_id] for section_id in ordered_ids]
+        self._assign_positions(ordered)
+        return ordered
+
+    def create_item(
+        self,
+        course_id: UUID,
+        section_id: UUID,
+        *,
+        title: str,
+        kind: str,
+        visibility: CourseContentVisibility,
+        resource_id: UUID | None,
+        payload: dict[str, Any],
+    ) -> CourseItem:
+        self._section(course_id, section_id)
+        resource_type, normalized_payload = self._validate_definition(
+            course_id=course_id,
+            kind=kind,
+            resource_id=resource_id,
+            payload=payload,
+        )
+        if resource_type is not None and resource_id is not None:
+            linked = self.db.scalar(
+                select(CourseItem.id).where(
+                    CourseItem.course_id == course_id,
+                    CourseItem.resource_type == resource_type,
+                    CourseItem.resource_id == resource_id,
+                )
+            )
+            if linked is not None:
+                raise CourseContentConflict(
+                    "This resource is already linked in the course content"
+                )
+        position = self.db.scalar(
+            select(func.max(CourseItem.position)).where(
+                CourseItem.section_id == section_id
+            )
+        )
+        item = CourseItem(
+            course_id=course_id,
+            section_id=section_id,
+            title=self._required_text(title, "Item title"),
+            position=(position + 1) if position is not None else 0,
+            kind=kind,
+            visibility=visibility,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            payload_schema_uri=PAYLOAD_SCHEMAS[kind],
+            payload=normalized_payload,
+        )
+        self.db.add(item)
+        self.db.flush()
+        return item
+
+    def update_item(
+        self, course_id: UUID, item_id: UUID, changes: dict[str, Any]
+    ) -> CourseItem:
+        item = self._item(course_id, item_id)
+        if "title" in changes:
+            item.title = self._required_text(changes["title"], "Item title")
+        if "visibility" in changes:
+            item.visibility = changes["visibility"]
+        if "payload" in changes:
+            _, item.payload = self._validate_definition(
+                course_id=course_id,
+                kind=item.kind,
+                resource_id=item.resource_id,
+                payload=changes["payload"],
+            )
+        self.db.flush()
+        return item
+
+    def delete_item(self, course_id: UUID, item_id: UUID) -> None:
+        item = self._item(course_id, item_id)
+        section_id = item.section_id
+        self.db.delete(item)
+        self.db.flush()
+        self._compact_items(section_id)
+
+    def reorder_items(
+        self, course_id: UUID, section_id: UUID, ordered_ids: list[UUID]
+    ) -> list[CourseItem]:
+        self._section(course_id, section_id)
+        items = self.db.scalars(
+            select(CourseItem)
+            .where(
+                CourseItem.course_id == course_id,
+                CourseItem.section_id == section_id,
+            )
+            .order_by(CourseItem.position)
+            .with_for_update()
+        ).all()
+        self._validate_exact_order(
+            ordered_ids,
+            [item.id for item in items],
+            "item",
+        )
+        by_id = {item.id: item for item in items}
+        ordered = [by_id[item_id] for item_id in ordered_ids]
+        self._assign_positions(ordered)
+        return ordered
+
+    def _section(self, course_id: UUID, section_id: UUID) -> CourseSection:
+        section = self.db.scalar(
+            select(CourseSection).where(
+                CourseSection.id == section_id,
+                CourseSection.course_id == course_id,
+            )
+        )
+        if section is None:
+            raise CourseContentNotFound("Course section not found")
+        return section
+
+    def _item(self, course_id: UUID, item_id: UUID) -> CourseItem:
+        item = self.db.scalar(
+            select(CourseItem).where(
+                CourseItem.id == item_id,
+                CourseItem.course_id == course_id,
+            )
+        )
+        if item is None:
+            raise CourseContentNotFound("Course item not found")
+        return item
+
+    def _validate_definition(
+        self,
+        *,
+        course_id: UUID,
+        kind: str,
+        resource_id: UUID | None,
+        payload: dict[str, Any] | None,
+    ) -> tuple[str | None, dict[str, Any]]:
+        if kind not in COURSE_ITEM_KINDS:
+            raise CourseContentError(f"Unsupported course item kind: {kind}")
+        if not isinstance(payload, dict):
+            raise CourseContentError("Item payload must be an object")
+
+        if kind == "page":
+            if resource_id is not None or set(payload) != {"body"}:
+                raise CourseContentError("Page items require only a body payload")
+            body = payload.get("body")
+            if not isinstance(body, str) or not body.strip():
+                raise CourseContentError("Page body is required")
+            return None, {"body": body.strip()}
+
+        if kind == "link":
+            if resource_id is not None or set(payload) != {"url"}:
+                raise CourseContentError("Link items require only a URL payload")
+            raw_url = payload.get("url")
+            if not isinstance(raw_url, str):
+                raise CourseContentError("Link URL is required")
+            url = raw_url.strip()
+            parsed = urlsplit(url)
+            if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                raise CourseContentError("Link URL must use http or https")
+            return None, {"url": url}
+
+        if kind == "heading":
+            if resource_id is not None or payload:
+                raise CourseContentError("Heading items cannot link a resource or payload")
+            return None, {}
+
+        if payload:
+            raise CourseContentError(f"{kind.title()} items cannot have a payload")
+        if resource_id is None:
+            raise CourseContentError(f"{kind.title()} resource is required")
+
+        if kind == "assignment":
+            assignment = self.db.get(Assignment, resource_id)
+            if assignment is None or assignment.course_id != course_id:
+                raise CourseContentError(
+                    "Assignment items must link an assignment from this course"
+                )
+        elif kind == "file":
+            artifact = self.db.get(Artifact, resource_id)
+            if (
+                artifact is None
+                or artifact.course_id != course_id
+                or _enum_value(artifact.status) == ArtifactStatus.archived.value
+                or _enum_value(artifact.access_level)
+                not in {AccessLevel.course.value, AccessLevel.public.value}
+            ):
+                raise CourseContentError(
+                    "File items must link an active course-visible artifact from this course"
+                )
+        return RESOURCE_TYPES[kind], {}
+
+    def _compact_sections(self, course_id: UUID) -> None:
+        sections = self.db.scalars(
+            select(CourseSection)
+            .where(CourseSection.course_id == course_id)
+            .order_by(CourseSection.position, CourseSection.id)
+            .with_for_update()
+        ).all()
+        self._assign_positions(sections)
+
+    def _compact_items(self, section_id: UUID) -> None:
+        items = self.db.scalars(
+            select(CourseItem)
+            .where(CourseItem.section_id == section_id)
+            .order_by(CourseItem.position, CourseItem.id)
+            .with_for_update()
+        ).all()
+        self._assign_positions(items)
+
+    def _assign_positions(self, ordered: list[CourseSection] | list[CourseItem]) -> None:
+        if not ordered:
+            return
+        temporary_start = max(item.position for item in ordered) + len(ordered) + 1
+        for index, item in enumerate(ordered):
+            item.position = temporary_start + index
+        self.db.flush()
+        for index, item in enumerate(ordered):
+            item.position = index
+        self.db.flush()
+
+    @staticmethod
+    def _validate_exact_order(
+        requested: list[UUID], existing: list[UUID], entity: str
+    ) -> None:
+        if len(requested) != len(set(requested)):
+            raise CourseContentConflict(f"Ordered {entity} IDs contain duplicates")
+        if set(requested) != set(existing):
+            raise CourseContentConflict(
+                f"Ordered {entity} IDs must exactly match current membership"
+            )
+
+    @staticmethod
+    def _required_text(value: object, label: str) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise CourseContentError(f"{label} is required")
+        return value.strip()
+
+    @staticmethod
+    def _optional_text(value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise CourseContentError("Summary must be text")
+        stripped = value.strip()
+        return stripped or None
+
+
+__all__ = [
+    "CourseContentConflict",
+    "CourseContentError",
+    "CourseContentNotFound",
+    "CourseContentService",
+]

--- a/tests/test_course_content_api.py
+++ b/tests/test_course_content_api.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from uuid import uuid4
 
 from fair_platform.backend.api.routers.auth import hash_password
-from fair_platform.backend.data.models.artifact import AccessLevel, Artifact
-from fair_platform.backend.data.models.assignment import Assignment, AssignmentStatus
+from fair_platform.backend.data.models.artifact import (
+    AccessLevel,
+    Artifact,
+    ArtifactStatus,
+)
+from fair_platform.backend.data.models.assignment import (
+    Assignment,
+    AssignmentStatus,
+)
 from fair_platform.backend.data.models.course import Course
 from fair_platform.backend.data.models.enrollment import Enrollment, EnrollmentStatus
 from fair_platform.backend.data.models.lms_content import (
@@ -313,3 +321,208 @@ def test_removed_membership_cannot_open_course_artifact(test_db):
         enrollment.status = EnrollmentStatus.active
         session.commit()
         assert manager.can_view(student, artifact) is True
+
+
+def test_resource_deletion_removes_outline_links_and_compacts_positions(
+    test_client, test_db
+):
+    with test_db() as session:
+        owner = _user(session, "Owner", UserRole.instructor)
+        course = _course(session, owner)
+        assignment = Assignment(
+            id=uuid4(),
+            course_id=course.id,
+            title="Disposable assignment",
+            max_grade={"type": "points", "value": 100},
+            status=AssignmentStatus.draft,
+        )
+        deleted_artifact = Artifact(
+            id=uuid4(),
+            title="Disposable file",
+            artifact_type="document",
+            creator_id=owner.id,
+            status=ArtifactStatus.attached,
+            access_level=AccessLevel.course,
+            course_id=course.id,
+        )
+        archived_artifact = Artifact(
+            id=uuid4(),
+            title="Archivable file",
+            artifact_type="document",
+            creator_id=owner.id,
+            status=ArtifactStatus.attached,
+            access_level=AccessLevel.course,
+            course_id=course.id,
+        )
+        section = CourseSection(
+            id=uuid4(),
+            course_id=course.id,
+            title="Resources",
+            position=0,
+            visibility=CourseContentVisibility.published,
+        )
+        session.add_all(
+            [assignment, deleted_artifact, archived_artifact, section]
+        )
+        session.flush()
+        assignment_item = CourseItem(
+            id=uuid4(),
+            course_id=course.id,
+            section_id=section.id,
+            title=assignment.title,
+            position=0,
+            kind="assignment",
+            visibility=CourseContentVisibility.draft,
+            resource_type="assignment",
+            resource_id=assignment.id,
+            payload={},
+        )
+        deleted_artifact_item = CourseItem(
+            id=uuid4(),
+            course_id=course.id,
+            section_id=section.id,
+            title=deleted_artifact.title,
+            position=1,
+            kind="file",
+            visibility=CourseContentVisibility.published,
+            resource_type="artifact",
+            resource_id=deleted_artifact.id,
+            payload={},
+        )
+        archived_artifact_item = CourseItem(
+            id=uuid4(),
+            course_id=course.id,
+            section_id=section.id,
+            title=archived_artifact.title,
+            position=2,
+            kind="file",
+            visibility=CourseContentVisibility.published,
+            resource_type="artifact",
+            resource_id=archived_artifact.id,
+            payload={},
+        )
+        surviving_item = CourseItem(
+            id=uuid4(),
+            course_id=course.id,
+            section_id=section.id,
+            title="Keep me",
+            position=3,
+            kind="page",
+            visibility=CourseContentVisibility.published,
+            copied_from_id=assignment_item.id,
+            payload_schema_uri="urn:fair:lms:course-item:page:v1",
+            payload={"body": "Still here"},
+        )
+        session.add_all(
+            [
+                assignment_item,
+                deleted_artifact_item,
+                archived_artifact_item,
+                surviving_item,
+            ]
+        )
+        session.commit()
+
+    headers = _auth(test_client, owner)
+    response = test_client.delete(
+        f"/api/assignments/{assignment.id}", headers=headers
+    )
+    assert response.status_code == 204
+
+    with test_db() as session:
+        assert session.get(Assignment, assignment.id) is None
+        assert session.get(CourseItem, assignment_item.id) is None
+        remaining = (
+            session.query(CourseItem)
+            .filter(CourseItem.section_id == section.id)
+            .order_by(CourseItem.position)
+            .all()
+        )
+        assert [item.id for item in remaining] == [
+            deleted_artifact_item.id,
+            archived_artifact_item.id,
+            surviving_item.id,
+        ]
+        assert [item.position for item in remaining] == [0, 1, 2]
+        assert session.get(CourseItem, surviving_item.id).copied_from_id is None
+
+    response = test_client.delete(
+        f"/api/v1/artifacts/{deleted_artifact.id}", headers=headers
+    )
+    assert response.status_code == 204
+
+    with test_db() as session:
+        assert (
+            session.get(Artifact, deleted_artifact.id).status
+            == ArtifactStatus.archived
+        )
+        assert session.get(CourseItem, deleted_artifact_item.id) is None
+
+    response = test_client.put(
+        f"/api/v1/artifacts/{archived_artifact.id}",
+        json={"status": "archived"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+
+    with test_db() as session:
+        assert (
+            session.get(Artifact, archived_artifact.id).status
+            == ArtifactStatus.archived
+        )
+        assert session.get(CourseItem, archived_artifact_item.id) is None
+        remaining = (
+            session.query(CourseItem)
+            .filter(CourseItem.section_id == section.id)
+            .order_by(CourseItem.position)
+            .all()
+        )
+        assert [(item.id, item.position) for item in remaining] == [
+            (surviving_item.id, 0)
+        ]
+
+
+def test_orphan_cleanup_removes_outline_link(test_db):
+    with test_db() as session:
+        owner = _user(session, "Owner", UserRole.instructor)
+        course = _course(session, owner)
+        artifact = Artifact(
+            id=uuid4(),
+            title="Expired orphan",
+            artifact_type="document",
+            creator_id=owner.id,
+            status=ArtifactStatus.orphaned,
+            access_level=AccessLevel.course,
+            course_id=course.id,
+            updated_at=datetime.now() - timedelta(days=8),
+        )
+        section = CourseSection(
+            id=uuid4(),
+            course_id=course.id,
+            title="Resources",
+            position=0,
+            visibility=CourseContentVisibility.published,
+        )
+        session.add_all([artifact, section])
+        session.flush()
+        item = CourseItem(
+            id=uuid4(),
+            course_id=course.id,
+            section_id=section.id,
+            title=artifact.title,
+            position=0,
+            kind="file",
+            visibility=CourseContentVisibility.published,
+            resource_type="artifact",
+            resource_id=artifact.id,
+            payload={},
+        )
+        session.add(item)
+        session.commit()
+
+        manager = ArtifactManager(session, storage_provider=object())
+        assert manager.cleanup_orphaned() == 1
+        session.commit()
+
+        assert session.get(Artifact, artifact.id).status == ArtifactStatus.archived
+        assert session.get(CourseItem, item.id) is None

--- a/tests/test_course_content_api.py
+++ b/tests/test_course_content_api.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fair_platform.backend.api.routers.auth import hash_password
+from fair_platform.backend.data.models.artifact import AccessLevel, Artifact
+from fair_platform.backend.data.models.assignment import Assignment, AssignmentStatus
+from fair_platform.backend.data.models.course import Course
+from fair_platform.backend.data.models.enrollment import Enrollment, EnrollmentStatus
+from fair_platform.backend.data.models.lms_content import (
+    CourseContentVisibility,
+    CourseItem,
+    CourseSection,
+)
+from fair_platform.backend.data.models.user import User, UserRole
+from fair_platform.backend.services.artifact_manager import ArtifactManager
+from tests.conftest import get_auth_token
+
+
+def _user(session, name: str, role: UserRole) -> User:
+    user = User(
+        id=uuid4(),
+        name=name,
+        email=f"{name.lower()}-{uuid4().hex[:6]}@test.com",
+        role=role,
+        password_hash=hash_password("test_password_123"),
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    return user
+
+
+def _auth(client, user: User) -> dict[str, str]:
+    token = get_auth_token(client, str(user.email))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _course(session, owner: User, *, archived: bool = False) -> Course:
+    course = Course(
+        id=uuid4(),
+        name="Course builder",
+        instructor_id=owner.id,
+        is_archived=archived,
+    )
+    session.add(course)
+    session.commit()
+    return course
+
+
+def test_staff_crud_and_exact_membership_reorder(test_client, test_db):
+    with test_db() as session:
+        owner = _user(session, "Owner", UserRole.instructor)
+        course = _course(session, owner)
+    headers = _auth(test_client, owner)
+
+    section_ids = []
+    for title in ("Week one", "Week two"):
+        response = test_client.post(
+            f"/api/lms/courses/{course.id}/sections",
+            json={"title": title, "visibility": "published"},
+            headers=headers,
+        )
+        assert response.status_code == 201
+        section_ids.append(response.json()["id"])
+
+    rejected = test_client.put(
+        f"/api/lms/courses/{course.id}/sections/order",
+        json={"orderedIds": [section_ids[0]]},
+        headers=headers,
+    )
+    assert rejected.status_code == 409
+
+    reordered = test_client.put(
+        f"/api/lms/courses/{course.id}/sections/order",
+        json={"orderedIds": list(reversed(section_ids))},
+        headers=headers,
+    )
+    assert reordered.status_code == 200
+    assert [section["id"] for section in reordered.json()] == list(
+        reversed(section_ids)
+    )
+    assert [section["position"] for section in reordered.json()] == [0, 1]
+
+    item_ids = []
+    for payload in (
+        {
+            "title": "Read this first",
+            "kind": "page",
+            "visibility": "published",
+            "payload": {"body": "Welcome to **FAIR**."},
+        },
+        {
+            "title": "Reference",
+            "kind": "link",
+            "visibility": "published",
+            "payload": {"url": "https://example.com/reference"},
+        },
+    ):
+        response = test_client.post(
+            f"/api/lms/courses/{course.id}/sections/{section_ids[0]}/items",
+            json=payload,
+            headers=headers,
+        )
+        assert response.status_code == 201
+        item_ids.append(response.json()["id"])
+
+    duplicate_order = test_client.put(
+        f"/api/lms/courses/{course.id}/sections/{section_ids[0]}/items/order",
+        json={"orderedIds": [item_ids[0], item_ids[0]]},
+        headers=headers,
+    )
+    assert duplicate_order.status_code == 409
+
+    reordered_items = test_client.put(
+        f"/api/lms/courses/{course.id}/sections/{section_ids[0]}/items/order",
+        json={"orderedIds": list(reversed(item_ids))},
+        headers=headers,
+    )
+    assert reordered_items.status_code == 200
+    assert [item["id"] for item in reordered_items.json()] == list(reversed(item_ids))
+
+    deleted = test_client.delete(
+        f"/api/lms/courses/{course.id}/items/{item_ids[1]}", headers=headers
+    )
+    assert deleted.status_code == 204
+    outline = test_client.get(
+        f"/api/lms/courses/{course.id}/content", headers=headers
+    ).json()
+    first_section = next(
+        section for section in outline["sections"] if section["id"] == section_ids[0]
+    )
+    assert [(item["id"], item["position"]) for item in first_section["items"]] == [
+        (item_ids[0], 0)
+    ]
+
+
+def test_visibility_permissions_and_archived_read_only(test_client, test_db):
+    with test_db() as session:
+        owner = _user(session, "Owner", UserRole.instructor)
+        student = _user(session, "Student", UserRole.student)
+        outsider = _user(session, "Outsider", UserRole.student)
+        course = _course(session, owner)
+        published_assignment = Assignment(
+            id=uuid4(),
+            course_id=course.id,
+            title="Published assignment",
+            max_grade={"type": "points", "value": 100},
+            status=AssignmentStatus.published,
+        )
+        draft_assignment = Assignment(
+            id=uuid4(),
+            course_id=course.id,
+            title="Draft assignment",
+            max_grade={"type": "points", "value": 100},
+            status=AssignmentStatus.draft,
+        )
+        published_section = CourseSection(
+            id=uuid4(),
+            course_id=course.id,
+            title="Published section",
+            position=0,
+            visibility=CourseContentVisibility.published,
+        )
+        draft_section = CourseSection(
+            id=uuid4(),
+            course_id=course.id,
+            title="Draft section",
+            position=1,
+            visibility=CourseContentVisibility.draft,
+        )
+        session.add_all(
+            [published_assignment, draft_assignment, published_section, draft_section]
+        )
+        session.flush()
+        session.add_all(
+            [
+                Enrollment(id=uuid4(), user_id=student.id, course_id=course.id),
+                CourseItem(
+                    id=uuid4(),
+                    course_id=course.id,
+                    section_id=published_section.id,
+                    title="Welcome",
+                    position=0,
+                    kind="page",
+                    visibility=CourseContentVisibility.published,
+                    payload_schema_uri="urn:fair:lms:course-item:page:v1",
+                    payload={"body": "Visible page"},
+                ),
+                CourseItem(
+                    id=uuid4(),
+                    course_id=course.id,
+                    section_id=published_section.id,
+                    title="Published assignment",
+                    position=1,
+                    kind="assignment",
+                    visibility=CourseContentVisibility.published,
+                    resource_type="assignment",
+                    resource_id=published_assignment.id,
+                    payload={},
+                ),
+                CourseItem(
+                    id=uuid4(),
+                    course_id=course.id,
+                    section_id=published_section.id,
+                    title="Draft item",
+                    position=2,
+                    kind="heading",
+                    visibility=CourseContentVisibility.draft,
+                    payload={},
+                ),
+                CourseItem(
+                    id=uuid4(),
+                    course_id=course.id,
+                    section_id=published_section.id,
+                    title="Draft assignment",
+                    position=3,
+                    kind="assignment",
+                    visibility=CourseContentVisibility.published,
+                    resource_type="assignment",
+                    resource_id=draft_assignment.id,
+                    payload={},
+                ),
+                CourseItem(
+                    id=uuid4(),
+                    course_id=course.id,
+                    section_id=draft_section.id,
+                    title="Hidden by section",
+                    position=0,
+                    kind="heading",
+                    visibility=CourseContentVisibility.published,
+                    payload={},
+                ),
+            ]
+        )
+        session.commit()
+
+    student_view = test_client.get(
+        f"/api/lms/courses/{course.id}/content", headers=_auth(test_client, student)
+    )
+    assert student_view.status_code == 200
+    assert student_view.json()["canManage"] is False
+    assert [section["title"] for section in student_view.json()["sections"]] == [
+        "Published section"
+    ]
+    assert [item["title"] for item in student_view.json()["sections"][0]["items"]] == [
+        "Welcome",
+        "Published assignment",
+    ]
+
+    assert (
+        test_client.get(
+            f"/api/lms/courses/{course.id}/content",
+            headers=_auth(test_client, outsider),
+        ).status_code
+        == 403
+    )
+    assert (
+        test_client.post(
+            f"/api/lms/courses/{course.id}/sections",
+            json={"title": "No access"},
+            headers=_auth(test_client, student),
+        ).status_code
+        == 403
+    )
+
+    with test_db() as session:
+        session.get(Course, course.id).is_archived = True
+        session.commit()
+    owner_headers = _auth(test_client, owner)
+    assert (
+        test_client.get(
+            f"/api/lms/courses/{course.id}/content", headers=owner_headers
+        ).status_code
+        == 200
+    )
+    assert (
+        test_client.post(
+            f"/api/lms/courses/{course.id}/sections",
+            json={"title": "Archived edit"},
+            headers=owner_headers,
+        ).status_code
+        == 409
+    )
+
+
+def test_removed_membership_cannot_open_course_artifact(test_db):
+    with test_db() as session:
+        owner = _user(session, "Owner", UserRole.instructor)
+        student = _user(session, "Removed", UserRole.student)
+        course = _course(session, owner)
+        enrollment = Enrollment(
+            id=uuid4(),
+            user_id=student.id,
+            course_id=course.id,
+            status=EnrollmentStatus.removed,
+        )
+        artifact = Artifact(
+            id=uuid4(),
+            title="Syllabus",
+            artifact_type="document",
+            creator_id=owner.id,
+            status="attached",
+            access_level=AccessLevel.course,
+            course_id=course.id,
+        )
+        session.add_all([enrollment, artifact])
+        session.commit()
+
+        manager = ArtifactManager(session, storage_provider=object())
+        assert manager.can_view(student, artifact) is False
+
+        enrollment.status = EnrollmentStatus.active
+        session.commit()
+        assert manager.can_view(student, artifact) is True

--- a/tests/test_course_content_backfill.py
+++ b/tests/test_course_content_backfill.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy import create_engine
+
+from fair_platform.backend.data.migrations import (
+    build_alembic_config,
+    run_migrations_to_head,
+    run_migrations_to_revision,
+)
+
+
+P0_REVISION = "20260812_0029"
+
+
+def _seed_pre_content_data(database_url: str) -> dict[str, object]:
+    engine = create_engine(database_url)
+    users = sa.table(
+        "users",
+        sa.column("id", sa.UUID()),
+        sa.column("name", sa.String()),
+        sa.column("email", sa.String()),
+        sa.column("role", sa.String()),
+        sa.column("password_hash", sa.String()),
+        sa.column("settings", sa.JSON()),
+        sa.column("is_verified", sa.Boolean()),
+    )
+    courses = sa.table(
+        "courses",
+        sa.column("id", sa.UUID()),
+        sa.column("name", sa.String()),
+        sa.column("description", sa.Text()),
+        sa.column("instructor_id", sa.UUID()),
+        sa.column("organization_id", sa.UUID()),
+        sa.column("enrollment_code", sa.String()),
+        sa.column("is_enrollment_enabled", sa.Boolean()),
+        sa.column("section", sa.String()),
+        sa.column("term", sa.String()),
+        sa.column("is_archived", sa.Boolean()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+    assignments = sa.table(
+        "assignments",
+        sa.column("id", sa.UUID()),
+        sa.column("course_id", sa.UUID()),
+        sa.column("title", sa.String()),
+        sa.column("description", sa.Text()),
+        sa.column("deadline", sa.DateTime(timezone=True)),
+        sa.column("max_grade", sa.JSON()),
+        sa.column("status", sa.String()),
+        sa.column("published_at", sa.DateTime(timezone=True)),
+        sa.column("allow_resubmissions", sa.Boolean()),
+    )
+    sections = sa.table(
+        "course_sections",
+        sa.column("id", sa.UUID()),
+        sa.column("course_id", sa.UUID()),
+        sa.column("title", sa.String()),
+        sa.column("summary", sa.Text()),
+        sa.column("position", sa.Integer()),
+        sa.column("visibility", sa.String()),
+        sa.column("copied_from_id", sa.UUID()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+    items = sa.table(
+        "course_items",
+        sa.column("id", sa.UUID()),
+        sa.column("course_id", sa.UUID()),
+        sa.column("section_id", sa.UUID()),
+        sa.column("title", sa.String()),
+        sa.column("position", sa.Integer()),
+        sa.column("kind", sa.String()),
+        sa.column("visibility", sa.String()),
+        sa.column("resource_type", sa.String()),
+        sa.column("resource_id", sa.UUID()),
+        sa.column("copied_from_id", sa.UUID()),
+        sa.column("payload_schema_uri", sa.String()),
+        sa.column("payload", sa.JSON()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+    owner_id = uuid4()
+    populated_course_id = uuid4()
+    empty_course_id = uuid4()
+    teacher_section_id = uuid4()
+    same_title_section_id = uuid4()
+    linked_assignment_id = uuid4()
+    missing_assignment_id = uuid4()
+    linked_item_id = uuid4()
+    now = datetime.now(timezone.utc)
+    with engine.begin() as connection:
+        connection.execute(
+            users.insert().values(
+                id=owner_id,
+                name="Backfill Owner",
+                email=f"backfill-{uuid4()}@example.test",
+                role="instructor",
+                password_hash=None,
+                is_verified=True,
+                settings={},
+            )
+        )
+        for course_id, name in (
+            (populated_course_id, "Existing assignments"),
+            (empty_course_id, "No assignments"),
+        ):
+            connection.execute(
+                courses.insert().values(
+                    id=course_id,
+                    name=name,
+                    description=None,
+                    instructor_id=owner_id,
+                    organization_id=None,
+                    enrollment_code=None,
+                    is_enrollment_enabled=True,
+                    section=None,
+                    term=None,
+                    is_archived=False,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        for assignment_id, title, assignment_status in (
+            (linked_assignment_id, "Already placed", "published"),
+            (missing_assignment_id, "Needs placement", "draft"),
+        ):
+            connection.execute(
+                assignments.insert().values(
+                    id=assignment_id,
+                    course_id=populated_course_id,
+                    title=title,
+                    description=None,
+                    deadline=None,
+                    max_grade={"type": "points", "value": 100},
+                    status=assignment_status,
+                    published_at=None,
+                    allow_resubmissions=True,
+                )
+            )
+        connection.execute(
+            sections.insert(),
+            [
+                {
+                    "id": teacher_section_id,
+                    "course_id": populated_course_id,
+                    "title": "Existing outline",
+                    "summary": "Teacher-authored content",
+                    "position": 0,
+                    "visibility": "published",
+                    "copied_from_id": None,
+                    "created_at": now,
+                    "updated_at": now,
+                },
+                {
+                    "id": same_title_section_id,
+                    "course_id": empty_course_id,
+                    "title": "Course content",
+                    "summary": "Assignments already available in this course.",
+                    "position": 0,
+                    "visibility": "published",
+                    "copied_from_id": None,
+                    "created_at": now,
+                    "updated_at": now,
+                },
+            ],
+        )
+        connection.execute(
+            items.insert().values(
+                id=linked_item_id,
+                course_id=populated_course_id,
+                section_id=teacher_section_id,
+                title="Already placed",
+                position=0,
+                kind="assignment",
+                visibility="published",
+                resource_type="assignment",
+                resource_id=linked_assignment_id,
+                copied_from_id=None,
+                payload_schema_uri="urn:test:existing-assignment:v1",
+                payload={},
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    engine.dispose()
+    return {
+        "populated_course_id": populated_course_id,
+        "empty_course_id": empty_course_id,
+        "teacher_section_id": teacher_section_id,
+        "same_title_section_id": same_title_section_id,
+        "linked_assignment_id": linked_assignment_id,
+        "missing_assignment_id": missing_assignment_id,
+        "linked_item_id": linked_item_id,
+    }
+
+
+def _content_rows(database_url: str) -> tuple[list[dict], list[dict]]:
+    engine = create_engine(database_url)
+    # SQLite reflects UUID columns as NUMERIC, which applies a Decimal result
+    # processor to the stored UUID text. Keep the rehearsal dialect-neutral by
+    # declaring only the columns whose values the assertions inspect.
+    sections = sa.table(
+        "course_sections",
+        sa.column("id", sa.UUID()),
+        sa.column("course_id", sa.UUID()),
+        sa.column("position", sa.Integer()),
+    )
+    items = sa.table(
+        "course_items",
+        sa.column("id", sa.UUID()),
+        sa.column("course_id", sa.UUID()),
+        sa.column("title", sa.String()),
+        sa.column("position", sa.Integer()),
+        sa.column("kind", sa.String()),
+        sa.column("visibility", sa.String()),
+        sa.column("resource_type", sa.String()),
+        sa.column("resource_id", sa.UUID()),
+        sa.column("payload_schema_uri", sa.String()),
+    )
+    with engine.connect() as connection:
+        section_rows = list(
+            connection.execute(
+                sa.select(sections).order_by(sections.c.course_id)
+            ).mappings()
+        )
+        item_rows = list(
+            connection.execute(sa.select(items).order_by(items.c.title)).mappings()
+        )
+    engine.dispose()
+    return section_rows, item_rows
+
+
+def test_backfill_upgrade_downgrade_and_reupgrade(tmp_path) -> None:
+    database_url = f"sqlite:///{(tmp_path / 'content-backfill.sqlite').as_posix()}"
+    run_migrations_to_revision(P0_REVISION, database_url)
+    seeded = _seed_pre_content_data(database_url)
+
+    run_migrations_to_head(database_url)
+    sections, items = _content_rows(database_url)
+    assert len(sections) == 3
+    populated_sections = [
+        row for row in sections if row["course_id"] == seeded["populated_course_id"]
+    ]
+    assert {row["position"] for row in populated_sections} == {0, 1}
+    assert any(row["id"] == seeded["teacher_section_id"] for row in sections)
+    assert any(row["id"] == seeded["same_title_section_id"] for row in sections)
+    assert len(items) == 2
+    assert {row["resource_id"] for row in items} == {
+        seeded["linked_assignment_id"],
+        seeded["missing_assignment_id"],
+    }
+    existing = next(row for row in items if row["id"] == seeded["linked_item_id"])
+    assert existing["payload_schema_uri"] == "urn:test:existing-assignment:v1"
+    backfilled = next(
+        row for row in items if row["resource_id"] == seeded["missing_assignment_id"]
+    )
+    assert backfilled["visibility"] == "draft"
+    assert all(row["resource_type"] == "assignment" for row in items)
+
+    command.downgrade(build_alembic_config(database_url), P0_REVISION)
+    sections, items = _content_rows(database_url)
+    assert {row["id"] for row in sections} == {
+        seeded["teacher_section_id"],
+        seeded["same_title_section_id"],
+    }
+    assert [row["id"] for row in items] == [seeded["linked_item_id"]]
+
+    run_migrations_to_head(database_url)
+    sections, items = _content_rows(database_url)
+    assert len(sections) == 3
+    assert len(items) == 2

--- a/tests/test_lms_primitives_migration.py
+++ b/tests/test_lms_primitives_migration.py
@@ -12,7 +12,6 @@ from sqlalchemy.exc import DatabaseError
 from fair_platform.backend.data.database import Base
 from fair_platform.backend.data.migrations import (
     build_alembic_config,
-    run_migrations_to_head,
     run_migrations_to_revision,
 )
 import fair_platform.backend.data.models  # noqa: F401
@@ -55,9 +54,11 @@ def _revision(path: Path) -> str:
     return row[0]
 
 
-def test_primitives_revision_is_the_sole_head() -> None:
+def test_primitives_revision_has_the_expected_parent() -> None:
     script = ScriptDirectory.from_config(build_alembic_config("sqlite:///:memory:"))
-    assert script.get_heads() == [PRIMITIVES_REVISION]
+    revision = script.get_revision(PRIMITIVES_REVISION)
+    assert revision is not None
+    assert revision.down_revision == PRIOR_REVISION
 
 
 def test_upgrade_from_points_head_has_model_column_parity(tmp_path: Path) -> None:
@@ -66,7 +67,7 @@ def test_upgrade_from_points_head_has_model_column_parity(tmp_path: Path) -> Non
     run_migrations_to_revision(PRIOR_REVISION, database_url)
     assert _revision(database_path) == PRIOR_REVISION
 
-    run_migrations_to_head(database_url)
+    run_migrations_to_revision(PRIMITIVES_REVISION, database_url)
     assert _revision(database_path) == PRIMITIVES_REVISION
 
     engine = create_engine(database_url)
@@ -87,7 +88,7 @@ def test_upgrade_from_points_head_has_model_column_parity(tmp_path: Path) -> Non
 def test_activity_event_trigger_rejects_raw_update_and_delete(tmp_path: Path) -> None:
     database_path = tmp_path / "activity-events.sqlite"
     database_url = _database_url(database_path)
-    run_migrations_to_head(database_url)
+    run_migrations_to_revision(PRIMITIVES_REVISION, database_url)
 
     engine = create_engine(database_url)
     with engine.begin() as connection:
@@ -123,7 +124,7 @@ def test_primitives_migration_downgrades_and_reupgrades_cleanly(
     database_path = tmp_path / "round-trip.sqlite"
     database_url = _database_url(database_path)
     config = build_alembic_config(database_url)
-    run_migrations_to_head(database_url)
+    run_migrations_to_revision(PRIMITIVES_REVISION, database_url)
 
     command.downgrade(config, PRIOR_REVISION)
     assert _revision(database_path) == PRIOR_REVISION
@@ -136,7 +137,7 @@ def test_primitives_migration_downgrades_and_reupgrades_cleanly(
         }
     engine.dispose()
 
-    run_migrations_to_head(database_url)
+    run_migrations_to_revision(PRIMITIVES_REVISION, database_url)
     assert _revision(database_path) == PRIMITIVES_REVISION
 
 


### PR DESCRIPTION
## Summary

Adds the first complete LMS course-outline experience on top of the primitives in #221.

- staff section and item CRUD with stable ordering
- extensible heading, page, link, file, and assignment item kinds
- learner-safe publication filtering enforced by the backend
- same-course assignment and protected-artifact validation
- authenticated file opening from the Content tab
- deterministic, reversible legacy-assignment backfill
- Content tab UI, dialogs, hooks, tests, OpenAPI, and docs

## Safety and compatibility

- preserves the existing Assignments tab and routes
- blocks writes for archived courses
- skips assignment resources already present in an outline
- appends generated content after teacher-authored positions
- removes only deterministically generated backfill content on downgrade
- requires an active enrollment for direct course/assignment artifact access

## Validation

- backend regression slice: 42 passed
- focused course-content review: 4 passed
- frontend Vitest: 3 passed
- frontend production build: passed
- Ruff check: passed
- OpenAPI regenerated
- Alembic: sole `20260812_0030` head
- migration rehearsal: `0029 -> 0030 -> 0029 -> 0030`
- independent blocker re-review: clean

## Stack

This PR is intentionally based on `codex/lms-primitives` so reviewers see only A1. After #221 merges, it should be retargeted to `canary`; no merge is requested yet.

Linear: RD-81