### PR TITLE
fix: align gradebook projection contracts

### DIFF
--- a/src/fair_platform/backend/alembic/versions/20260812_0031_gradebook_2_backfill.py
+++ b/src/fair_platform/backend/alembic/versions/20260812_0031_gradebook_2_backfill.py
@@ -71,11 +71,15 @@ def _aware(value: datetime | None, fallback: datetime) -> datetime:
     return result.astimezone(timezone.utc)
 
 
-def _submission_rank(row: Mapping[str, Any], now: datetime) -> tuple[int, float, str]:
-    released_at = _aware(row["returned_at"] or row["submitted_at"], now)
+def _submission_rank(row: Mapping[str, Any]) -> tuple[int, float, str]:
+    """Mirror the runtime attempt/submitted-at/UUID recency contract exactly."""
+
+    submitted_at = row["submitted_at"]
     return (
-        int(row["attempt_number"] or 0),
-        released_at.timestamp(),
+        int(row["attempt_number"]) if row["attempt_number"] is not None else -1,
+        _aware(submitted_at, submitted_at).timestamp()
+        if submitted_at is not None
+        else float("-inf"),
         str(row["id"]),
     )
 
@@ -342,9 +346,7 @@ def upgrade() -> None:
             continue
         key = (submission["assignment_id"], user_id)
         current = latest_by_assignment_user.get(key)
-        if current is None or _submission_rank(submission, now) > _submission_rank(
-            current, now
-        ):
+        if current is None or _submission_rank(submission) > _submission_rank(current):
             latest_by_assignment_user[key] = submission
 
     existing_entries = {

--- a/src/fair_platform/backend/services/gradebook.py
+++ b/src/fair_platform/backend/services/gradebook.py
@@ -64,6 +64,22 @@ def _enum_value(value: Any) -> str:
     return value.value if hasattr(value, "value") else str(value)
 
 
+def _canonical_submission_order(*, newest_first: bool) -> tuple[Any, Any, Any]:
+    """Order attempts by number, submission time, and stable UUID tie-breaker."""
+
+    if newest_first:
+        return (
+            Submission.attempt_number.desc().nulls_last(),
+            Submission.submitted_at.desc().nulls_last(),
+            Submission.id.desc(),
+        )
+    return (
+        Submission.attempt_number.asc().nulls_first(),
+        Submission.submitted_at.asc().nulls_first(),
+        Submission.id.asc(),
+    )
+
+
 def _lock_course_order(db: Session, course_id: UUID) -> None:
     if db.get_bind().dialect.name == "sqlite":
         held_locks: dict[UUID, RLock] = db.info.setdefault(_SESSION_ORDER_LOCKS_KEY, {})
@@ -130,11 +146,7 @@ def legacy_course_grading_data(
     submissions = (
         db.query(Submission)
         .filter(Submission.assignment_id.in_(assignment_ids))
-        .order_by(
-            Submission.attempt_number,
-            Submission.submitted_at,
-            Submission.id,
-        )
+        .order_by(*_canonical_submission_order(newest_first=False))
         .all()
         if assignment_ids
         else []
@@ -251,17 +263,6 @@ def sync_assignment_user_grade_entry(
     """
 
     item = ensure_assignment_grade_item(db, assignment)
-    enrollment = (
-        db.query(Enrollment)
-        .filter(
-            Enrollment.course_id == assignment.course_id,
-            Enrollment.user_id == user_id,
-        )
-        .one_or_none()
-    )
-    if enrollment is None:
-        return None
-
     entry = (
         db.query(GradeEntry)
         .filter(
@@ -270,6 +271,21 @@ def sync_assignment_user_grade_entry(
         )
         .one_or_none()
     )
+    enrollment = (
+        db.query(Enrollment)
+        .filter(
+            Enrollment.course_id == assignment.course_id,
+            Enrollment.user_id == user_id,
+            Enrollment.role == CourseMembershipRole.student,
+            Enrollment.status == EnrollmentStatus.active,
+        )
+        .one_or_none()
+    )
+    if enrollment is None:
+        if entry is not None:
+            db.delete(entry)
+            db.flush()
+        return None
     submission = (
         db.query(Submission)
         .join(Submitter, Submitter.id == Submission.submitter_id)
@@ -278,11 +294,7 @@ def sync_assignment_user_grade_entry(
             Submitter.user_id == user_id,
             Submitter.is_synthetic.is_(False),
         )
-        .order_by(
-            Submission.attempt_number.desc(),
-            Submission.submitted_at.desc(),
-            Submission.id.desc(),
-        )
+        .order_by(*_canonical_submission_order(newest_first=True))
         .first()
     )
     if submission is None:

--- a/tests/test_gradebook_backfill.py
+++ b/tests/test_gradebook_backfill.py
@@ -245,6 +245,66 @@ def test_gradebook_backfill_upgrade_downgrade_and_reupgrade(tmp_path: Path) -> N
     assert len(entries) == 2
 
 
+def test_gradebook_backfill_ranks_tied_attempts_by_submission_time(
+    tmp_path: Path,
+) -> None:
+    database_url = (
+        f"sqlite:///{(tmp_path / 'gradebook-tied-attempts.sqlite').as_posix()}"
+    )
+    run_migrations_to_revision(A1_REVISION, database_url)
+    seeded = _seed_legacy_grade_data(database_url)
+    engine = create_engine(database_url)
+    submitters = Base.metadata.tables["submitters"]
+    submissions = Base.metadata.tables["submissions"]
+    competing_submitter_id = uuid4()
+    competing_submission_id = uuid4()
+    with engine.begin() as connection:
+        canonical = (
+            connection.execute(
+                sa.select(submissions).where(
+                    submissions.c.id == seeded["latest_returned_id"]
+                )
+            )
+            .mappings()
+            .one()
+        )
+        connection.execute(
+            submitters.insert().values(
+                id=competing_submitter_id,
+                name="Backfill Student",
+                email="duplicate-backfill-student@example.test",
+                user_id=seeded["student_id"],
+                is_synthetic=False,
+                created_at=canonical["submitted_at"],
+            )
+        )
+        connection.execute(
+            submissions.insert().values(
+                id=competing_submission_id,
+                assignment_id=seeded["returned_assignment_id"],
+                submitter_id=competing_submitter_id,
+                created_by_id=seeded["student_id"],
+                submitted_at=canonical["submitted_at"] - timedelta(minutes=1),
+                status="returned",
+                draft_score=64,
+                draft_feedback=None,
+                published_score=64,
+                published_feedback=None,
+                returned_at=canonical["submitted_at"] + timedelta(days=1),
+                attempt_number=canonical["attempt_number"],
+                is_late=False,
+            )
+        )
+    engine.dispose()
+
+    run_migrations_to_revision(A3_REVISION, database_url)
+    _, _, entries = _gradebook_rows(database_url)
+    graded = next(entry for entry in entries if entry["status"] == "graded")
+    assert graded["source_id"] == seeded["latest_returned_id"]
+    assert graded["source_id"] != competing_submission_id
+    assert float(graded["points_earned"]) == 85
+
+
 def test_gradebook_backfill_rejects_invalid_published_scores(tmp_path: Path) -> None:
     database_url = f"sqlite:///{(tmp_path / 'gradebook-invalid.sqlite').as_posix()}"
     run_migrations_to_revision(A1_REVISION, database_url)

--- a/tests/test_gradebook_service.py
+++ b/tests/test_gradebook_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from threading import Event, Thread
 from uuid import uuid4
 
@@ -9,7 +9,11 @@ from fastapi import HTTPException
 
 from fair_platform.backend.data.models.assignment import Assignment, AssignmentStatus
 from fair_platform.backend.data.models.course import Course
-from fair_platform.backend.data.models.enrollment import Enrollment
+from fair_platform.backend.data.models.enrollment import (
+    CourseMembershipRole,
+    Enrollment,
+    EnrollmentStatus,
+)
 from fair_platform.backend.data.models.lms_gradebook import GradeCategory, GradeEntry
 from fair_platform.backend.data.models.submission import Submission, SubmissionStatus
 from fair_platform.backend.data.models.submitter import Submitter
@@ -120,6 +124,91 @@ def test_assignment_item_sync_and_published_only_projection(test_db):
         assert revised.id == entry.id
         assert float(revised.points_earned) == submission.published_score == 74
         assert float(revised.points_earned) != submission.draft_score
+
+
+@pytest.mark.parametrize(
+    ("role", "status"),
+    [
+        (CourseMembershipRole.student, EnrollmentStatus.removed),
+        (CourseMembershipRole.assistant, EnrollmentStatus.active),
+    ],
+)
+def test_assignment_projection_requires_active_student_enrollment(
+    test_db, role, status
+):
+    with test_db() as session:
+        owner, student, _, course, assignment, submitter = _fixture(session)
+        submission = Submission(
+            id=uuid4(),
+            assignment_id=assignment.id,
+            submitter_id=submitter.id,
+            created_by_id=student.id,
+            submitted_at=datetime.utcnow(),
+            status=SubmissionStatus.returned,
+            published_score=73,
+            returned_at=datetime.utcnow(),
+        )
+        session.add(submission)
+        session.flush()
+        assert sync_released_submission_entry(session, submission, owner) is not None
+        assert session.query(GradeEntry).count() == 1
+
+        enrollment = (
+            session.query(Enrollment)
+            .filter(
+                Enrollment.course_id == course.id,
+                Enrollment.user_id == student.id,
+            )
+            .one()
+        )
+        enrollment.role = role
+        enrollment.status = status
+        session.flush()
+
+        assert sync_released_submission_entry(session, submission, owner) is None
+        assert session.query(GradeEntry).count() == 0
+
+
+def test_assignment_projection_ranks_tied_attempts_by_submission_time(test_db):
+    with test_db() as session:
+        owner, student, _, _, assignment, first_submitter = _fixture(session)
+        second_submitter = Submitter(
+            id=uuid4(),
+            user_id=student.id,
+            name=student.name,
+            email=str(student.email),
+            is_synthetic=False,
+        )
+        now = datetime.utcnow()
+        later_submitted = Submission(
+            id=uuid4(),
+            assignment_id=assignment.id,
+            submitter_id=first_submitter.id,
+            created_by_id=student.id,
+            submitted_at=now,
+            returned_at=now + timedelta(minutes=1),
+            attempt_number=1,
+            status=SubmissionStatus.returned,
+            published_score=88,
+        )
+        later_returned = Submission(
+            id=uuid4(),
+            assignment_id=assignment.id,
+            submitter_id=second_submitter.id,
+            created_by_id=student.id,
+            submitted_at=now - timedelta(minutes=1),
+            returned_at=now + timedelta(days=1),
+            attempt_number=1,
+            status=SubmissionStatus.returned,
+            published_score=64,
+        )
+        session.add_all([second_submitter, later_submitted, later_returned])
+        session.flush()
+
+        entry = sync_released_submission_entry(session, later_returned, owner)
+        assert entry is not None
+        assert entry.source_id == later_submitted.id
+        assert float(entry.points_earned) == 88
 
 
 def test_manual_entries_require_active_student_and_compute_honest_totals(test_db):


### PR DESCRIPTION
Fixes blockers found while reviewing #223. Makes runtime and migration use the same canonical latest-attempt ordering, requires an active student enrollment before projecting released submission grades, removes stale projected entries after role/status changes, and adds regression coverage for duplicate submitters and membership transitions. Validation: 19 focused backend tests passed; Ruff check/format and diff check passed.