### PR TITLE
fix: prioritize actionable dashboard work

### DIFF
--- a/src/fair_platform/backend/services/student_dashboard.py
+++ b/src/fair_platform/backend/services/student_dashboard.py
@@ -336,6 +336,20 @@ def work_projection(
             "submission_id": submission.id if submission else None,
         }
         (overdue if state == "overdue" else upcoming).append(payload)
+
+    def work_sort_key(item: dict[str, Any]) -> tuple[Any, ...]:
+        deadline = item["deadline"]
+        return (
+            item["state"] == "submitted",
+            deadline is None,
+            deadline or now,
+            item["course_name"].casefold(),
+            item["title"].casefold(),
+            str(item["assignment_id"]),
+        )
+
+    upcoming.sort(key=work_sort_key)
+    overdue.sort(key=work_sort_key)
     return upcoming[:20], overdue[:20]
 
 

--- a/tests/test_student_dashboard_api.py
+++ b/tests/test_student_dashboard_api.py
@@ -376,6 +376,59 @@ def test_dashboard_returns_other_sources_when_progress_fails(
     }
 
 
+def test_dashboard_prioritizes_actionable_dated_work_before_the_limit(
+    test_client, test_db
+):
+    with test_db() as session:
+        _, _, student, _, course, _ = _setup(session)
+        now = datetime.now(timezone.utc)
+        undated = [
+            Assignment(
+                id=uuid4(),
+                course_id=course.id,
+                title=f"Undated practice {index:02d}",
+                deadline=None,
+                max_grade={"type": "points", "value": 10},
+                status=AssignmentStatus.published,
+                published_at=now,
+            )
+            for index in range(21)
+        ]
+        submitted_assignment = Assignment(
+            id=uuid4(),
+            course_id=course.id,
+            title="Already submitted",
+            deadline=now + timedelta(hours=1),
+            max_grade={"type": "points", "value": 10},
+            status=AssignmentStatus.published,
+            published_at=now,
+        )
+        session.add_all([*undated, submitted_assignment])
+        session.flush()
+        submitter = session.query(Submitter).filter_by(user_id=student.id).one()
+        session.add(
+            Submission(
+                id=uuid4(),
+                assignment_id=submitted_assignment.id,
+                submitter_id=submitter.id,
+                created_by_id=student.id,
+                submitted_at=now,
+                status=SubmissionStatus.submitted,
+                attempt_number=1,
+            )
+        )
+        session.commit()
+
+    response = test_client.get(
+        "/api/lms/student/dashboard", headers=_auth(test_client, student)
+    )
+    assert response.status_code == 200
+    upcoming = response.json()["upcomingWork"]
+    assert len(upcoming) == 20
+    assert upcoming[0]["title"] == "Cell diagram"
+    assert all(item["state"] == "upcoming" for item in upcoming)
+
+
 def test_dashboard_work_respects_private_due_override_cutoff_and_completion(
     test_client, test_db
 ):


### PR DESCRIPTION
Follow-up from the #224 review. Sorts the learner dashboard after applying private due-date overrides and state classification, so imminent actionable work cannot be crowded out of the 20-item limit by undated or already-submitted assignments. Adds a regression covering the limit. Validation: all 9 student-dashboard backend tests passed; Ruff check/format and diff check passed.