### PR TITLE
fix: maintain course content resource lifecycle

### DIFF
--- a/src/fair_platform/backend/api/routers/assignments.py
+++ b/src/fair_platform/backend/api/routers/assignments.py
@@ -32,6 +32,7 @@ from fair_platform.backend.data.models.enrollment import (
 )
 from fair_platform.backend.services.artifact_manager import get_artifact_manager
 from fair_platform.backend.services.course_access import can_manage_course
+from fair_platform.backend.services.course_content_service import CourseContentService
 from fair_platform.backend.services.notifications import notify_course_members
 
 router = APIRouter()
@@ -309,18 +310,23 @@ def delete_assignment(
             detail="Only the course instructor or admin can delete this assignment",
         )
 
-    submissions = (
-        db.query(Submission)
-        .filter(Submission.assignment_id == assignment_id)
-        .all()
-    )
-    for submission in submissions:
-        submission.artifacts.clear()
-        submission.runs.clear()
-        db.delete(submission)
+    try:
+        CourseContentService(db).remove_resource_links("assignment", assignment_id)
+        submissions = (
+            db.query(Submission)
+            .filter(Submission.assignment_id == assignment_id)
+            .all()
+        )
+        for submission in submissions:
+            submission.artifacts.clear()
+            submission.runs.clear()
+            db.delete(submission)
 
-    db.delete(assignment)
-    db.commit()
+        db.delete(assignment)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
     return None
 
 

--- a/src/fair_platform/backend/services/artifact_manager.py
+++ b/src/fair_platform/backend/services/artifact_manager.py
@@ -27,6 +27,7 @@ from fair_platform.backend.core.security.permissions import (
     has_capability,
     has_capability_and_owner,
 )
+from fair_platform.backend.services.course_content_service import CourseContentService
 
 
 class ArtifactManager:
@@ -272,6 +273,10 @@ class ArtifactManager:
         if status is not None:
             self._validate_status_transition(artifact.status, status)
             artifact.status = status
+            if status == ArtifactStatus.archived:
+                CourseContentService(self.db).remove_resource_links(
+                    "artifact", artifact.id
+                )
         if course_id is not None:
             artifact.course_id = course_id
         if assignment_id is not None:
@@ -313,14 +318,17 @@ class ArtifactManager:
         
         if not self.can_delete(user, artifact):
             raise HTTPException(status_code=403, detail="Permission denied")
-        
+
         if hard_delete:
             if not has_capability(user, "cleanup_orphaned_artifacts"):
                 raise HTTPException(
                     status_code=403,
                     detail="Hard delete requires admin privileges"
                 )
-            
+
+        CourseContentService(self.db).remove_resource_links("artifact", artifact.id)
+
+        if hard_delete:
             for derivative in list(artifact.derivatives):
                 self._delete_derivative_object(derivative.storage_uri)
             
@@ -613,6 +621,9 @@ class ArtifactManager:
         
         count = 0
         for artifact in orphaned_artifacts:
+            CourseContentService(self.db).remove_resource_links(
+                "artifact", artifact.id
+            )
             if hard_delete:
                 for derivative in list(artifact.derivatives):
                     self._delete_derivative_object(derivative.storage_uri)

--- a/src/fair_platform/backend/services/course_content_service.py
+++ b/src/fair_platform/backend/services/course_content_service.py
@@ -243,6 +243,33 @@ class CourseContentService:
         self.db.flush()
         self._compact_items(section_id)
 
+    def remove_resource_links(self, resource_type: str, resource_id: UUID) -> int:
+        """Remove outline links to a deleted resource and repair item ordering."""
+        items = self.db.scalars(
+            select(CourseItem)
+            .where(
+                CourseItem.resource_type == resource_type,
+                CourseItem.resource_id == resource_id,
+            )
+            .with_for_update()
+        ).all()
+        item_ids = [item.id for item in items]
+        if item_ids:
+            copied_items = self.db.scalars(
+                select(CourseItem)
+                .where(CourseItem.copied_from_id.in_(item_ids))
+                .with_for_update()
+            ).all()
+            for copied_item in copied_items:
+                copied_item.copied_from_id = None
+        section_ids = {item.section_id for item in items}
+        for item in items:
+            self.db.delete(item)
+        self.db.flush()
+        for section_id in sorted(section_ids, key=str):
+            self._compact_items(section_id)
+        return len(items)
+
     def reorder_items(
         self, course_id: UUID, section_id: UUID, ordered_ids: list[UUID]
     ) -> list[CourseItem]:

--- a/tests/test_course_content_api.py
+++ b/tests/test_course_content_api.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from uuid import uuid4
 
 from fair_platform.backend.api.routers.auth import hash_password
-from fair_platform.backend.data.models.artifact import AccessLevel, Artifact
-from fair_platform.backend.data.models.assignment import Assignment, AssignmentStatus
+from fair_platform.backend.data.models.artifact import (
+    AccessLevel,
+    Artifact,
+    ArtifactStatus,
+)
+from fair_platform.backend.data.models.assignment import (
+    Assignment,
+    AssignmentStatus,
+)
 from fair_platform.backend.data.models.course import Course
 from fair_platform.backend.data.models.enrollment import Enrollment, EnrollmentStatus
 from fair_platform.backend.data.models.lms_content import (
@@ -313,3 +321,208 @@ def test_removed_membership_cannot_open_course_artifact(test_db):
         enrollment.status = EnrollmentStatus.active
         session.commit()
         assert manager.can_view(student, artifact) is True
+
+
+def test_resource_deletion_removes_outline_links_and_compacts_positions(
+    test_client, test_db
+):
+    with test_db() as session:
+        owner = _user(session, "Owner", UserRole.instructor)
+        course = _course(session, owner)
+        assignment = Assignment(
+            id=uuid4(),
+            course_id=course.id,
+            title="Disposable assignment",
+            max_grade={"type": "points", "value": 100},
+            status=AssignmentStatus.draft,
+        )
+        deleted_artifact = Artifact(
+            id=uuid4(),
+            title="Disposable file",
+            artifact_type="document",
+            creator_id=owner.id,
+            status=ArtifactStatus.attached,
+            access_level=AccessLevel.course,
+            course_id=course.id,
+        )
+        archived_artifact = Artifact(
+            id=uuid4(),
+            title="Archivable file",
+            artifact_type="document",
+            creator_id=owner.id,
+            status=ArtifactStatus.attached,
+            access_level=AccessLevel.course,
+            course_id=course.id,
+        )
+        section = CourseSection(
+            id=uuid4(),
+            course_id=course.id,
+            title="Resources",
+            position=0,
+            visibility=CourseContentVisibility.published,
+        )
+        session.add_all(
+            [assignment, deleted_artifact, archived_artifact, section]
+        )
+        session.flush()
+        assignment_item = CourseItem(
+            id=uuid4(),
+            course_id=course.id,
+            section_id=section.id,
+            title=assignment.title,
+            position=0,
+            kind="assignment",
+            visibility=CourseContentVisibility.draft,
+            resource_type="assignment",
+            resource_id=assignment.id,
+            payload={},
+        )
+        deleted_artifact_item = CourseItem(
+            id=uuid4(),
+            course_id=course.id,
+            section_id=section.id,
+            title=deleted_artifact.title,
+            position=1,
+            kind="file",
+            visibility=CourseContentVisibility.published,
+            resource_type="artifact",
+            resource_id=deleted_artifact.id,
+            payload={},
+        )
+        archived_artifact_item = CourseItem(
+            id=uuid4(),
+            course_id=course.id,
+            section_id=section.id,
+            title=archived_artifact.title,
+            position=2,
+            kind="file",
+            visibility=CourseContentVisibility.published,
+            resource_type="artifact",
+            resource_id=archived_artifact.id,
+            payload={},
+        )
+        surviving_item = CourseItem(
+            id=uuid4(),
+            course_id=course.id,
+            section_id=section.id,
+            title="Keep me",
+            position=3,
+            kind="page",
+            visibility=CourseContentVisibility.published,
+            copied_from_id=assignment_item.id,
+            payload_schema_uri="urn:fair:lms:course-item:page:v1",
+            payload={"body": "Still here"},
+        )
+        session.add_all(
+            [
+                assignment_item,
+                deleted_artifact_item,
+                archived_artifact_item,
+                surviving_item,
+            ]
+        )
+        session.commit()
+
+    headers = _auth(test_client, owner)
+    response = test_client.delete(
+        f"/api/assignments/{assignment.id}", headers=headers
+    )
+    assert response.status_code == 204
+
+    with test_db() as session:
+        assert session.get(Assignment, assignment.id) is None
+        assert session.get(CourseItem, assignment_item.id) is None
+        remaining = (
+            session.query(CourseItem)
+            .filter(CourseItem.section_id == section.id)
+            .order_by(CourseItem.position)
+            .all()
+        )
+        assert [item.id for item in remaining] == [
+            deleted_artifact_item.id,
+            archived_artifact_item.id,
+            surviving_item.id,
+        ]
+        assert [item.position for item in remaining] == [0, 1, 2]
+        assert session.get(CourseItem, surviving_item.id).copied_from_id is None
+
+    response = test_client.delete(
+        f"/api/v1/artifacts/{deleted_artifact.id}", headers=headers
+    )
+    assert response.status_code == 204
+
+    with test_db() as session:
+        assert (
+            session.get(Artifact, deleted_artifact.id).status
+            == ArtifactStatus.archived
+        )
+        assert session.get(CourseItem, deleted_artifact_item.id) is None
+
+    response = test_client.put(
+        f"/api/v1/artifacts/{archived_artifact.id}",
+        json={"status": "archived"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+
+    with test_db() as session:
+        assert (
+            session.get(Artifact, archived_artifact.id).status
+            == ArtifactStatus.archived
+        )
+        assert session.get(CourseItem, archived_artifact_item.id) is None
+        remaining = (
+            session.query(CourseItem)
+            .filter(CourseItem.section_id == section.id)
+            .order_by(CourseItem.position)
+            .all()
+        )
+        assert [(item.id, item.position) for item in remaining] == [
+            (surviving_item.id, 0)
+        ]
+
+
+def test_orphan_cleanup_removes_outline_link(test_db):
+    with test_db() as session:
+        owner = _user(session, "Owner", UserRole.instructor)
+        course = _course(session, owner)
+        artifact = Artifact(
+            id=uuid4(),
+            title="Expired orphan",
+            artifact_type="document",
+            creator_id=owner.id,
+            status=ArtifactStatus.orphaned,
+            access_level=AccessLevel.course,
+            course_id=course.id,
+            updated_at=datetime.now() - timedelta(days=8),
+        )
+        section = CourseSection(
+            id=uuid4(),
+            course_id=course.id,
+            title="Resources",
+            position=0,
+            visibility=CourseContentVisibility.published,
+        )
+        session.add_all([artifact, section])
+        session.flush()
+        item = CourseItem(
+            id=uuid4(),
+            course_id=course.id,
+            section_id=section.id,
+            title=artifact.title,
+            position=0,
+            kind="file",
+            visibility=CourseContentVisibility.published,
+            resource_type="artifact",
+            resource_id=artifact.id,
+            payload={},
+        )
+        session.add(item)
+        session.commit()
+
+        manager = ArtifactManager(session, storage_provider=object())
+        assert manager.cleanup_orphaned() == 1
+        session.commit()
+
+        assert session.get(Artifact, artifact.id).status == ArtifactStatus.archived
+        assert session.get(CourseItem, item.id) is None

--- a/tests/test_lms_primitives_migration.py
+++ b/tests/test_lms_primitives_migration.py
@@ -12,7 +12,6 @@ from sqlalchemy.exc import DatabaseError
 from fair_platform.backend.data.database import Base
 from fair_platform.backend.data.migrations import (
     build_alembic_config,
-    run_migrations_to_head,
     run_migrations_to_revision,
 )
 import fair_platform.backend.data.models  # noqa: F401
@@ -55,9 +54,11 @@ def _revision(path: Path) -> str:
     return row[0]
 
 
-def test_primitives_revision_is_the_sole_head() -> None:
+def test_primitives_revision_has_the_expected_parent() -> None:
     script = ScriptDirectory.from_config(build_alembic_config("sqlite:///:memory:"))
-    assert script.get_heads() == [PRIMITIVES_REVISION]
+    revision = script.get_revision(PRIMITIVES_REVISION)
+    assert revision is not None
+    assert revision.down_revision == PRIOR_REVISION
 
 
 def test_upgrade_from_points_head_has_model_column_parity(tmp_path: Path) -> None:
@@ -66,7 +67,7 @@ def test_upgrade_from_points_head_has_model_column_parity(tmp_path: Path) -> Non
     run_migrations_to_revision(PRIOR_REVISION, database_url)
     assert _revision(database_path) == PRIOR_REVISION
 
-    run_migrations_to_head(database_url)
+    run_migrations_to_revision(PRIMITIVES_REVISION, database_url)
     assert _revision(database_path) == PRIMITIVES_REVISION
 
     engine = create_engine(database_url)
@@ -87,7 +88,7 @@ def test_upgrade_from_points_head_has_model_column_parity(tmp_path: Path) -> Non
 def test_activity_event_trigger_rejects_raw_update_and_delete(tmp_path: Path) -> None:
     database_path = tmp_path / "activity-events.sqlite"
     database_url = _database_url(database_path)
-    run_migrations_to_head(database_url)
+    run_migrations_to_revision(PRIMITIVES_REVISION, database_url)
 
     engine = create_engine(database_url)
     with engine.begin() as connection:
@@ -123,7 +124,7 @@ def test_primitives_migration_downgrades_and_reupgrades_cleanly(
     database_path = tmp_path / "round-trip.sqlite"
     database_url = _database_url(database_path)
     config = build_alembic_config(database_url)
-    run_migrations_to_head(database_url)
+    run_migrations_to_revision(PRIMITIVES_REVISION, database_url)
 
     command.downgrade(config, PRIOR_REVISION)
     assert _revision(database_path) == PRIOR_REVISION
@@ -136,7 +137,7 @@ def test_primitives_migration_downgrades_and_reupgrades_cleanly(
         }
     engine.dispose()
 
-    run_migrations_to_head(database_url)
+    run_migrations_to_revision(PRIMITIVES_REVISION, database_url)
     assert _revision(database_path) == PRIMITIVES_REVISION
 
 


### PR DESCRIPTION
Fixes issues found while reviewing #222 and its refreshed full CI. Makes the 0029 migration tests target that revision explicitly instead of assuming it remains the global head; atomically removes assignment-backed course items when assignments are deleted; compacts positions and repairs copy provenance; and applies equivalent link cleanup when artifacts are archived, deleted, or orphan-cleaned. Validation: focused migration/course-content tests 10 passed; artifact lifecycle tests 3 passed; adjacent suite 41 passed; changed-file Ruff and diff checks passed.