### PR TITLE
feat: add configurable admission and AI cost controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,18 @@ SECRET_KEY=replace-for-shared-environments
 
 # FAIR institutional profile (uncomment and replace values)
 # FAIR_DEPLOYMENT_MODE=ENTERPRISE
+# Registration and AI policy defaults remain compatible when omitted: public
+# registration is open and weighted-credit enforcement is disabled. For a
+# shared deployment, these environment values lock the corresponding controls
+# in the admin UI. Classify capabilities and grant entitlements before enabling
+# AI controls.
+# FAIR_ADMISSION_MODE=invite_only
+# Approved-domain deployments should verify address ownership. Configure the
+# mail provider secret in the deployment secret store, not in source control.
+# FAIR_RESEND_API_KEY=replace-me
+# FAIR_EMAIL_ENABLED=1
+# FAIR_ENFORCE_EMAIL_VERIFICATION=1
+# FAIR_AI_CONTROLS_ENABLED=true
 # DATABASE_URL=postgresql+psycopg://fair:replace-me@postgres:5432/fair
 # FAIR_STORAGE_BACKEND=s3
 # S3_BUCKET_NAME=fair-institution

--- a/docs/assets/openapi.json
+++ b/docs/assets/openapi.json
@@ -1491,7 +1491,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UserCreate"
+                "$ref": "#/components/schemas/RegistrationRequest"
               }
             }
           },
@@ -5288,6 +5288,582 @@
         }
       }
     },
+    "/api/v1/admin/platform-policy": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Read Policy",
+        "operationId": "read_policy_api_v1_admin_platform_policy_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformPolicyRead"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Update Policy",
+        "operationId": "update_policy_api_v1_admin_platform_policy_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformPolicyUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformPolicyRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/admin/admission-rules": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "List Admission Rules",
+        "operationId": "list_admission_rules_api_v1_admin_admission_rules_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AdmissionRuleRead"
+                  },
+                  "type": "array",
+                  "title": "Response List Admission Rules Api V1 Admin Admission Rules Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Create Admission Rule",
+        "operationId": "create_admission_rule_api_v1_admin_admission_rules_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdmissionRuleCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdmissionRuleRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/admin/admission-rules/{rule_id}": {
+      "delete": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Delete Admission Rule",
+        "operationId": "delete_admission_rule_api_v1_admin_admission_rules__rule_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Rule Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/invites": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "List Invites",
+        "operationId": "list_invites_api_v1_admin_invites_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/InviteRead"
+                  },
+                  "type": "array",
+                  "title": "Response List Invites Api V1 Admin Invites Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Create Invite",
+        "operationId": "create_invite_api_v1_admin_invites_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InviteSecretRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/admin/invites/{invite_id}/revoke": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Revoke Invite",
+        "operationId": "revoke_invite_api_v1_admin_invites__invite_id__revoke_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "invite_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Invite Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InviteRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/capability-cost-policies": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "List Capability Cost Policies",
+        "operationId": "list_capability_cost_policies_api_v1_admin_capability_cost_policies_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/CapabilityCostPolicyRead"
+                  },
+                  "type": "array",
+                  "title": "Response List Capability Cost Policies Api V1 Admin Capability Cost Policies Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/admin/capability-cost-policies/{capability_id}": {
+      "put": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Put Capability Cost Policy",
+        "operationId": "put_capability_cost_policy_api_v1_admin_capability_cost_policies__capability_id__put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "capability_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Capability Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CapabilityCostPolicyUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CapabilityCostPolicyRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/ai-entitlements": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "List Ai Entitlements",
+        "operationId": "list_ai_entitlements_api_v1_admin_ai_entitlements_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AIEntitlementRead"
+                  },
+                  "type": "array",
+                  "title": "Response List Ai Entitlements Api V1 Admin Ai Entitlements Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/admin/users/{user_id}/ai-entitlement": {
+      "put": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Put Ai Entitlement",
+        "operationId": "put_ai_entitlement_api_v1_admin_users__user_id__ai_entitlement_put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "User Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AIEntitlementUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AIEntitlementRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/ai-usage": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Read Ai Usage",
+        "operationId": "read_ai_usage_api_v1_admin_ai_usage_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AIUsageRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ai/entitlement": {
+      "get": {
+        "tags": [
+          "ai-access"
+        ],
+        "summary": "Read My Ai Entitlement",
+        "operationId": "read_my_ai_entitlement_api_v1_ai_entitlement_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SelfAIEntitlementRead"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/system/config": {
       "get": {
         "tags": [
@@ -8837,6 +9413,263 @@
   },
   "components": {
     "schemas": {
+      "AIEntitlementRead": {
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Userid"
+          },
+          "userName": {
+            "type": "string",
+            "title": "Username"
+          },
+          "userEmail": {
+            "type": "string",
+            "format": "email",
+            "title": "Useremail"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "limited",
+              "unlimited"
+            ],
+            "title": "State"
+          },
+          "monthlyLimitUnits": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Monthlylimitunits"
+          },
+          "usedUnits": {
+            "type": "integer",
+            "title": "Usedunits"
+          },
+          "remainingUnits": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remainingunits"
+          },
+          "periodStart": {
+            "type": "string",
+            "format": "date",
+            "title": "Periodstart"
+          },
+          "nextResetAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Nextresetat"
+          },
+          "controlsEnabled": {
+            "type": "boolean",
+            "title": "Controlsenabled"
+          }
+        },
+        "type": "object",
+        "required": [
+          "userId",
+          "userName",
+          "userEmail",
+          "state",
+          "monthlyLimitUnits",
+          "usedUnits",
+          "remainingUnits",
+          "periodStart",
+          "nextResetAt",
+          "controlsEnabled"
+        ],
+        "title": "AIEntitlementRead"
+      },
+      "AIEntitlementUpdate": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "limited",
+              "unlimited"
+            ],
+            "title": "State"
+          },
+          "monthlyLimitUnits": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 1000000000.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Monthlylimitunits"
+          }
+        },
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "title": "AIEntitlementUpdate"
+      },
+      "AIUsageChargeRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "executionId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Executionid"
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Userid"
+          },
+          "userEmail": {
+            "type": "string",
+            "format": "email",
+            "title": "Useremail"
+          },
+          "capabilityDefinitionId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Capabilitydefinitionid"
+          },
+          "capabilityId": {
+            "type": "string",
+            "title": "Capabilityid"
+          },
+          "units": {
+            "type": "integer",
+            "title": "Units"
+          },
+          "periodStart": {
+            "type": "string",
+            "format": "date",
+            "title": "Periodstart"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Createdat"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "executionId",
+          "userId",
+          "userEmail",
+          "capabilityDefinitionId",
+          "capabilityId",
+          "units",
+          "periodStart",
+          "createdAt"
+        ],
+        "title": "AIUsageChargeRead"
+      },
+      "AIUsageRead": {
+        "properties": {
+          "periodStart": {
+            "type": "string",
+            "format": "date",
+            "title": "Periodstart"
+          },
+          "totalUnits": {
+            "type": "integer",
+            "title": "Totalunits"
+          },
+          "charges": {
+            "items": {
+              "$ref": "#/components/schemas/AIUsageChargeRead"
+            },
+            "type": "array",
+            "title": "Charges"
+          }
+        },
+        "type": "object",
+        "required": [
+          "periodStart",
+          "totalUnits",
+          "charges"
+        ],
+        "title": "AIUsageRead"
+      },
+      "AdmissionRuleCreate": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "email",
+              "domain"
+            ],
+            "title": "Kind"
+          },
+          "value": {
+            "type": "string",
+            "maxLength": 320,
+            "minLength": 1,
+            "title": "Value"
+          }
+        },
+        "type": "object",
+        "required": [
+          "kind",
+          "value"
+        ],
+        "title": "AdmissionRuleCreate"
+      },
+      "AdmissionRuleRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "email",
+              "domain"
+            ],
+            "title": "Kind"
+          },
+          "value": {
+            "type": "string",
+            "title": "Value"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Createdat"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "kind",
+          "value",
+          "createdAt"
+        ],
+        "title": "AdmissionRuleRead"
+      },
       "ArtifactCreate": {
         "properties": {
           "title": {
@@ -10391,6 +11224,168 @@
         ],
         "title": "Body_upload_artifacts_api_v1_artifacts_uploads_post"
       },
+      "CapabilityCostControlRead": {
+        "properties": {
+          "controlsEnabled": {
+            "type": "boolean",
+            "title": "Controlsenabled"
+          },
+          "classification": {
+            "type": "string",
+            "enum": [
+              "unclassified",
+              "unmetered",
+              "ai"
+            ],
+            "title": "Classification"
+          },
+          "costUnits": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Costunits"
+          },
+          "executable": {
+            "type": "boolean",
+            "title": "Executable"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "ai_policy_unconfigured",
+                  "ai_not_entitled",
+                  "ai_quota_exhausted"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          }
+        },
+        "type": "object",
+        "required": [
+          "controlsEnabled",
+          "classification",
+          "costUnits",
+          "executable",
+          "reason"
+        ],
+        "title": "CapabilityCostControlRead"
+      },
+      "CapabilityCostPolicyRead": {
+        "properties": {
+          "capabilityDefinitionId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Capabilitydefinitionid"
+          },
+          "capabilityId": {
+            "type": "string",
+            "title": "Capabilityid"
+          },
+          "displayName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Displayname"
+          },
+          "version": {
+            "type": "string",
+            "title": "Version"
+          },
+          "surface": {
+            "type": "string",
+            "title": "Surface"
+          },
+          "extensionId": {
+            "type": "string",
+            "title": "Extensionid"
+          },
+          "classification": {
+            "type": "string",
+            "enum": [
+              "unclassified",
+              "unmetered",
+              "ai"
+            ],
+            "title": "Classification"
+          },
+          "costUnits": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Costunits"
+          },
+          "updatedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updatedat"
+          }
+        },
+        "type": "object",
+        "required": [
+          "capabilityDefinitionId",
+          "capabilityId",
+          "displayName",
+          "version",
+          "surface",
+          "extensionId",
+          "classification",
+          "costUnits",
+          "updatedAt"
+        ],
+        "title": "CapabilityCostPolicyRead"
+      },
+      "CapabilityCostPolicyUpdate": {
+        "properties": {
+          "classification": {
+            "type": "string",
+            "enum": [
+              "unmetered",
+              "ai"
+            ],
+            "title": "Classification"
+          },
+          "costUnits": {
+            "type": "integer",
+            "maximum": 1000000.0,
+            "minimum": 0.0,
+            "title": "Costunits"
+          }
+        },
+        "type": "object",
+        "required": [
+          "classification",
+          "costUnits"
+        ],
+        "title": "CapabilityCostPolicyUpdate"
+      },
       "CapabilityManifest": {
         "properties": {
           "capabilityId": {
@@ -10635,6 +11630,16 @@
             "type": "string",
             "format": "date-time",
             "title": "Createdat"
+          },
+          "costControl": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CapabilityCostControlRead"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "additionalProperties": false,
@@ -15028,6 +16033,163 @@
         "type": "object",
         "title": "InteractionResolve"
       },
+      "InviteCreate": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "expiresInDays": {
+            "type": "integer",
+            "maximum": 90.0,
+            "minimum": 1.0,
+            "title": "Expiresindays",
+            "default": 7
+          }
+        },
+        "type": "object",
+        "required": [
+          "email"
+        ],
+        "title": "InviteCreate"
+      },
+      "InviteRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expiresat"
+          },
+          "redeemedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Redeemedat"
+          },
+          "revokedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revokedat"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Createdat"
+          },
+          "active": {
+            "type": "boolean",
+            "title": "Active"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "expiresAt",
+          "redeemedAt",
+          "revokedAt",
+          "createdAt",
+          "active"
+        ],
+        "title": "InviteRead"
+      },
+      "InviteSecretRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expiresat"
+          },
+          "redeemedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Redeemedat"
+          },
+          "revokedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revokedat"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Createdat"
+          },
+          "active": {
+            "type": "boolean",
+            "title": "Active"
+          },
+          "token": {
+            "type": "string",
+            "title": "Token"
+          },
+          "registrationUrl": {
+            "type": "string",
+            "title": "Registrationurl"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "expiresAt",
+          "redeemedAt",
+          "revokedAt",
+          "createdAt",
+          "active",
+          "token",
+          "registrationUrl"
+        ],
+        "title": "InviteSecretRead"
+      },
       "JsonSchemaDocument": {
         "properties": {
           "$schema": {
@@ -15181,6 +16343,118 @@
           "createdAt"
         ],
         "title": "NotificationRead"
+      },
+      "PlatformPolicyRead": {
+        "properties": {
+          "storedAdmissionMode": {
+            "type": "string",
+            "enum": [
+              "open",
+              "allowlist",
+              "invite_only"
+            ],
+            "title": "Storedadmissionmode"
+          },
+          "effectiveAdmissionMode": {
+            "type": "string",
+            "enum": [
+              "open",
+              "allowlist",
+              "invite_only"
+            ],
+            "title": "Effectiveadmissionmode"
+          },
+          "admissionSource": {
+            "type": "string",
+            "enum": [
+              "database",
+              "environment"
+            ],
+            "title": "Admissionsource"
+          },
+          "admissionLocked": {
+            "type": "boolean",
+            "title": "Admissionlocked"
+          },
+          "storedAiControlsEnabled": {
+            "type": "boolean",
+            "title": "Storedaicontrolsenabled"
+          },
+          "effectiveAiControlsEnabled": {
+            "type": "boolean",
+            "title": "Effectiveaicontrolsenabled"
+          },
+          "aiControlsSource": {
+            "type": "string",
+            "enum": [
+              "database",
+              "environment"
+            ],
+            "title": "Aicontrolssource"
+          },
+          "aiControlsLocked": {
+            "type": "boolean",
+            "title": "Aicontrolslocked"
+          },
+          "updatedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updatedat"
+          }
+        },
+        "type": "object",
+        "required": [
+          "storedAdmissionMode",
+          "effectiveAdmissionMode",
+          "admissionSource",
+          "admissionLocked",
+          "storedAiControlsEnabled",
+          "effectiveAiControlsEnabled",
+          "aiControlsSource",
+          "aiControlsLocked",
+          "updatedAt"
+        ],
+        "title": "PlatformPolicyRead"
+      },
+      "PlatformPolicyUpdate": {
+        "properties": {
+          "admissionMode": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "open",
+                  "allowlist",
+                  "invite_only"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Admissionmode"
+          },
+          "aiControlsEnabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aicontrolsenabled"
+          }
+        },
+        "type": "object",
+        "title": "PlatformPolicyUpdate"
       },
       "PointsGrade": {
         "properties": {
@@ -16041,6 +17315,46 @@
         ],
         "title": "QuizStatus"
       },
+      "RegistrationRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 8,
+            "title": "Password"
+          },
+          "inviteToken": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 512
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Invitetoken"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "email",
+          "password"
+        ],
+        "title": "RegistrationRequest"
+      },
       "ResendVerificationRequest": {
         "properties": {
           "email": {
@@ -16249,6 +17563,70 @@
           "leaseId"
         ],
         "title": "RunnerCommandAck"
+      },
+      "SelfAIEntitlementRead": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "disabled",
+              "limited",
+              "unlimited"
+            ],
+            "title": "State"
+          },
+          "monthlyLimitUnits": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Monthlylimitunits"
+          },
+          "usedUnits": {
+            "type": "integer",
+            "title": "Usedunits"
+          },
+          "remainingUnits": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remainingunits"
+          },
+          "periodStart": {
+            "type": "string",
+            "format": "date",
+            "title": "Periodstart"
+          },
+          "nextResetAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Nextresetat"
+          },
+          "controlsEnabled": {
+            "type": "boolean",
+            "title": "Controlsenabled"
+          }
+        },
+        "type": "object",
+        "required": [
+          "state",
+          "monthlyLimitUnits",
+          "usedUnits",
+          "remainingUnits",
+          "periodStart",
+          "nextResetAt",
+          "controlsEnabled"
+        ],
+        "title": "SelfAIEntitlementRead"
       },
       "StudentCourseActivity": {
         "properties": {
@@ -17592,39 +18970,6 @@
           "userMessageId"
         ],
         "title": "TurnRead"
-      },
-      "UserCreate": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "email": {
-            "type": "string",
-            "format": "email",
-            "title": "Email"
-          },
-          "role": {
-            "$ref": "#/components/schemas/UserRole",
-            "default": "user"
-          },
-          "isVerified": {
-            "type": "boolean",
-            "title": "Isverified",
-            "default": false
-          },
-          "password": {
-            "type": "string",
-            "title": "Password"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "email",
-          "password"
-        ],
-        "title": "UserCreate"
       },
       "UserRead": {
         "properties": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -66,6 +66,7 @@
                   "en/platform/lms-primitives",
                   "en/platform/flows",
                   "en/platform/integrations",
+                  "en/platform/access-controls",
                   "en/platform/settings"
                 ]
               },
@@ -160,6 +161,7 @@
                   "es/platform/foundational-api",
                   "es/platform/flows",
                   "es/platform/integrations",
+                  "es/platform/access-controls",
                   "es/platform/settings"
                 ]
               }

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -141,8 +141,8 @@ Getting students into your courses is now completely frictionless.
 
 Previously, users were locked into fixed roles—instructors couldn't join other courses as students, and students couldn't create courses. This made testing and demos difficult! We've migrated to a dynamic permissions system to solve this.
 
-* **Flexible Community Mode:** By default, users can now do both instructor and student tasks within the same account, making onboarding and using our [community instance](https://platform.fairgradeproject.org) a breeze.  
-* **Strict Enterprise Security:** Large universities that want to prevent students from accessing potentially expensive AI features can easily revert to the strict role behavior by simply setting `DEPLOYMENT_MODE=ENTERPRISE`.
+* **Flexible Community Mode:** By default, users can now do both instructor and student tasks within the same account, making onboarding in community-style deployments easier.
+* **Strict Enterprise Security:** Large universities can restore strict role behavior by setting `FAIR_DEPLOYMENT_MODE=ENTERPRISE`. Admission and AI entitlements are configured separately; deployment mode alone is not a spending control.
 
 ### **📊 Enhanced Logging & Artifacts**
 

--- a/docs/en/platform/access-controls.md
+++ b/docs/en/platform/access-controls.md
@@ -1,0 +1,69 @@
+---
+title: Admission and AI cost controls
+description: Configure registration policy and weighted AI execution credits for a shared FAIR deployment
+---
+
+FAIR treats admission and AI access as separate decisions. Admitting an account does not grant it AI spending authority, and course roles or extension grants do not replace either control.
+
+The compatibility defaults are **open registration** and **AI controls disabled**. Existing accounts can continue to sign in when an operator changes the registration policy.
+
+## Bootstrap an administrator
+
+Create the first verified administrator from the deployment environment rather than opening public registration:
+
+```bash
+fair users create-admin admin@example.edu --name "FAIR Administrator"
+```
+
+The command prompts for a password and bypasses only the public registration policy. Run database migrations before using the command.
+
+## Registration admission
+
+An administrator can choose a mode under **Settings → Admin → Admission**:
+
+| Mode | Registration behavior |
+|---|---|
+| Open | Any valid email address may register. |
+| Approved emails | The normalized address must match an approved individual address or its exact domain must be approved. Subdomains are not implicit wildcards. |
+| Invite only | Registration requires an unexpired, unrevoked, single-use token bound to the same normalized email address. |
+
+Administrators can add and remove exact email or domain rules and create or revoke invitations. The invitation URL is shown only when it is created. FAIR stores a hash of the token, not the plaintext token, and places the token in the URL fragment so it is not sent in the initial HTTP request. Registration with an invitation does not mark the email as verified; ordinary verification policy still applies.
+
+Use `FAIR_ADMISSION_MODE=open|allowlist|invite_only` when deployment configuration should be authoritative. When present, this value overrides the stored setting and locks the mode selector in the admin UI. Rules and invitations remain database-managed.
+
+An allowlist matches the address a registrant supplies; it is not proof that the registrant owns that mailbox. Internet-facing allowlist deployments should configure a mail provider and set both `FAIR_EMAIL_ENABLED=1` and `FAIR_ENFORCE_EMAIL_VERIFICATION=1`. Without enforced verification, an attacker can self-assert an address in an approved domain.
+
+## AI entitlements and weighted credits
+
+Enable AI controls only after completing both setup steps:
+
+1. Classify every installed capability as **unmetered** or **AI**, and assign a positive integer credit cost to each AI capability.
+2. Give each intended user a **disabled**, **limited**, or **unlimited** AI entitlement. A limited entitlement requires a monthly credit limit.
+
+When controls are enabled, FAIR reserves a capability's configured credits atomically before creating its dispatch. Chat agents, functions, and each Flow step use this central execution path. A request is denied before provider work begins when the capability is unclassified, the user lacks an entitlement, or the monthly limit would be exceeded. Monthly counters reset on the first day of the month in UTC.
+
+Credits are operator-defined weights, not provider tokens, currency, invoices, or a guaranteed dollar ceiling. A successful reservation is retained as an immutable usage charge even if the downstream provider later fails; refunds and provider-price reconciliation are outside the first version. Operators should choose conservative weights and reconcile the audit log with provider billing.
+
+`FAIR_AI_CONTROLS_ENABLED=true|false` overrides the stored enforcement switch and locks it in the admin UI. If it is set to `true` while a capability is unclassified, that capability fails closed. Omitting it leaves the switch database-managed and disabled by default.
+
+## Recommended rollout
+
+1. Back up the database and run the Alembic migration. It stops with an actionable error if existing emails collapse to the same normalized identity; FAIR never merges or deletes those users automatically.
+2. Create or confirm an administrator and keep registration open during validation.
+3. Add admission rules or invitations, test a new registration, then change the admission mode.
+4. Classify all capabilities and grant small test entitlements while AI controls remain disabled.
+5. Enable AI controls, exercise chat, function, and Flow paths, and review **Settings → Admin → AI controls** usage records.
+6. Raise user limits deliberately after comparing weighted credits with real provider usage.
+
+For rollback, set `FAIR_ADMISSION_MODE=open` and `FAIR_AI_CONTROLS_ENABLED=false`, or restore those stored values through the admin UI when environment overrides are absent. This preserves rules, invitations, entitlements, and the usage audit for later reuse.
+
+## Security and operations
+
+- Keep invitation links confidential and short-lived. Revoke unused links when recipients change.
+- Enforce email verification when admission depends on an approved address or domain. Possession of an invite link is the credential in invite-only mode, so protect it like a password-reset link.
+- Put internet-facing registration and login endpoints behind reverse-proxy or WAF rate limits and monitoring. IP allowlisting is not part of FAIR's application policy and is usually too coarse for a general deployment.
+- Use HTTPS, a strong `SECRET_KEY`, controlled administrator accounts, backups, and database least privilege.
+- Treat the UI as guidance only. The API enforces administrator authorization, admission rules, entitlements, and credit reservation server-side.
+- Registration admission does not suspend an existing account, assign course membership, grant extension effects, or prove ownership of an email address.
+
+The former FAIR public community instance is currently offline, and its future availability is not guaranteed. These controls are deployment-neutral and can be used by any FAIR operator.

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -3,21 +3,18 @@ title: Quickstart
 description: How to get started with FAIR Platform
 ---
 
-This page shows the fastest way to start using **FAIR Platform**. You can either try our community instance at [platform.fairgradeproject.org](https://platform.fairgradeproject.org) or install it locally on your machine. Both are, and will always be, completely free.
+This page shows the fastest dependable way to start using **FAIR Platform**: install the open-source application locally or operate your own deployment.
 
 <Card
-title="Community Instance"
-href="https://platform.fairgradeproject.org"
-arrow="true"
-cta="Explore the community instance"
+title="Public community instance status"
 img="/assets/showcase.png"
 horizontal>
-Our community instance lets you explore FAIR immediately. It’s the quickest way for educators and researchers to test features without needing to touch a terminal.
+FAIR's former public community instance is currently offline. It may be redeployed in the future, but public availability is not guaranteed. Use a local or operator-managed deployment when you need reliable access.
 </Card>
 
 ## What should I use?
-* The community instance is perfect for those who want a quick look at the interface or want to start experimenting with features right away.
-* The Local Installation is ideal for institutions that want full control over their data, or developers looking to build custom modules and contribute to the project.
+* A local installation is the quickest available route for evaluation, development, and reproducible research.
+* An operator-managed deployment is appropriate for institutions that need durable service, controlled registration, and explicit AI usage limits.
 
 For local use, FAIR is designed to be lightweight: it only needs one command to install and one command to run. No prior programming experience is required.
 
@@ -65,7 +62,7 @@ Installing FAIR is a simple three-step process.
     
     
 ## The CLI
-The `fair` command is your entry point for managing the platform. You can find a full list of capabilities in our [CLI documentation](/en/cli).
+The `fair` command is your entry point for managing the platform. You can find a full list of capabilities in our [CLI documentation](/en/cli). Operators of shared instances should also review [Admission and AI cost controls](/en/platform/access-controls).
 
 ## Troubleshooting
 If something doesn't look right during installation, please refer to our [troubleshooting guide](/en/troubleshooting) or open an issue on our [GitHub](https://github.com/azapg/fair).

--- a/docs/es/changelog.mdx
+++ b/docs/es/changelog.mdx
@@ -142,8 +142,8 @@ Ahora es completamente sencillo incorporar estudiantes a tus cursos.
 
 Anteriormente, los usuarios estaban limitados a roles fijos: los instructores no podían unirse a otros cursos como estudiantes, y los estudiantes no podían crear cursos. ¡Esto dificultaba las pruebas y demostraciones! Hemos migrado a un sistema de permisos dinámico para resolver esto.
 
-* **Modo Comunitario Flexible:** Por defecto, los usuarios ahora pueden realizar tanto tareas de instructor como de estudiante dentro de la misma cuenta, facilitando la incorporación y el uso de nuestra [instancia comunitaria](https://platform.fairgradeproject.org).  
-* **Seguridad Empresarial Estricta:** Las grandes universidades que desean evitar que los estudiantes accedan a funciones de IA potencialmente costosas pueden volver fácilmente al comportamiento estricto de roles simplemente configurando `DEPLOYMENT_MODE=ENTERPRISE`.
+* **Modo Comunitario Flexible:** Por defecto, los usuarios ahora pueden realizar tanto tareas de instructor como de estudiante dentro de la misma cuenta, facilitando la incorporación en despliegues de estilo comunitario.
+* **Seguridad Empresarial Estricta:** Las universidades pueden restaurar el comportamiento estricto de roles configurando `FAIR_DEPLOYMENT_MODE=ENTERPRISE`. La admisión y los permisos de IA se configuran por separado; el modo de despliegue por sí solo no controla el gasto.
 
 ### **📊 Registros y Artefactos Mejorados**
 

--- a/docs/es/platform/access-controls.md
+++ b/docs/es/platform/access-controls.md
@@ -1,0 +1,69 @@
+---
+title: Controles de admisión y costos de IA
+description: Configura la política de registro y los créditos ponderados de ejecución de IA para un despliegue compartido de FAIR
+---
+
+FAIR trata la admisión y el acceso a IA como decisiones separadas. Admitir una cuenta no le otorga autorización para gastar en IA, y los roles de curso o permisos de extensiones no reemplazan ninguno de estos controles.
+
+Los valores predeterminados compatibles son **registro abierto** y **controles de IA desactivados**. Las cuentas existentes pueden seguir iniciando sesión cuando el operador cambia la política de registro.
+
+## Crear el primer administrador
+
+Crea el primer administrador verificado desde el entorno del despliegue, sin abrir el registro público:
+
+```bash
+fair users create-admin admin@example.edu --name "Administrador de FAIR"
+```
+
+El comando solicita una contraseña y solo omite la política de registro público. Ejecuta las migraciones de base de datos antes de usarlo.
+
+## Admisión de registro
+
+Un administrador puede elegir un modo en **Configuración → Administración → Admisión**:
+
+| Modo | Comportamiento del registro |
+|---|---|
+| Abierto | Cualquier dirección de correo válida puede registrarse. |
+| Correos aprobados | La dirección normalizada debe coincidir con una dirección individual aprobada o su dominio exacto debe estar aprobado. Los subdominios no son comodines implícitos. |
+| Solo con invitación | El registro requiere un token vigente, no revocado, de un solo uso y vinculado a la misma dirección normalizada. |
+
+Los administradores pueden agregar o eliminar reglas exactas de correo o dominio y crear o revocar invitaciones. La URL de invitación se muestra una sola vez al crearla. FAIR almacena un hash del token, no el token en texto plano, y coloca el token en el fragmento de la URL para que no se envíe en la solicitud HTTP inicial. Registrarse con una invitación no marca el correo como verificado; la política normal de verificación todavía aplica.
+
+Usa `FAIR_ADMISSION_MODE=open|allowlist|invite_only` cuando la configuración del despliegue deba ser autoritativa. Al estar presente, este valor reemplaza la configuración almacenada y bloquea el selector de modo en la interfaz administrativa. Las reglas e invitaciones siguen gestionándose en la base de datos.
+
+Una lista de aprobación compara la dirección que declara la persona; no prueba que sea propietaria de ese buzón. Los despliegues públicos con listas de aprobación deben configurar un proveedor de correo y establecer `FAIR_EMAIL_ENABLED=1` y `FAIR_ENFORCE_EMAIL_VERIFICATION=1`. Sin verificación obligatoria, un atacante puede declarar una dirección de un dominio aprobado.
+
+## Permisos de IA y créditos ponderados
+
+Activa los controles de IA solo después de completar ambos pasos:
+
+1. Clasifica cada capacidad instalada como **sin medición** o **IA**, y asigna un costo entero positivo en créditos a cada capacidad de IA.
+2. Asigna a cada usuario previsto un permiso de IA **desactivado**, **limitado** o **ilimitado**. Un permiso limitado requiere un límite mensual de créditos.
+
+Cuando los controles están activos, FAIR reserva atómicamente los créditos configurados antes de crear el despacho. Los agentes de chat, funciones y cada paso de un flujo usan esta ruta central de ejecución. Una solicitud se rechaza antes de iniciar trabajo del proveedor si la capacidad no está clasificada, el usuario no tiene permiso o se excedería el límite mensual. Los contadores se reinician el primer día del mes en UTC.
+
+Los créditos son ponderaciones definidas por el operador, no tokens del proveedor, moneda, facturas ni un techo garantizado en dólares. Una reserva exitosa se conserva como cargo de uso inmutable aunque el proveedor falle después; los reembolsos y la conciliación de precios quedan fuera de esta primera versión. El operador debe usar ponderaciones conservadoras y conciliar el registro de auditoría con la facturación del proveedor.
+
+`FAIR_AI_CONTROLS_ENABLED=true|false` reemplaza el interruptor almacenado y lo bloquea en la interfaz administrativa. Si se establece en `true` mientras una capacidad no está clasificada, esa capacidad falla de forma cerrada. Si se omite, el interruptor se gestiona en la base de datos y permanece desactivado por defecto.
+
+## Despliegue por etapas recomendado
+
+1. Respalda la base de datos y ejecuta la migración de Alembic. Esta se detiene con un error accionable si correos existentes convergen en la misma identidad normalizada; FAIR nunca fusiona ni elimina esos usuarios automáticamente.
+2. Crea o confirma un administrador y mantén el registro abierto durante la validación.
+3. Agrega reglas o invitaciones, prueba un registro nuevo y luego cambia el modo de admisión.
+4. Clasifica todas las capacidades y asigna permisos pequeños de prueba mientras los controles de IA siguen desactivados.
+5. Activa los controles, prueba chat, funciones y flujos, y revisa los registros de uso en **Configuración → Administración → Controles de IA**.
+6. Aumenta los límites deliberadamente después de comparar los créditos ponderados con el uso real del proveedor.
+
+Para revertir la política, configura `FAIR_ADMISSION_MODE=open` y `FAIR_AI_CONTROLS_ENABLED=false`, o restaura esos valores desde la interfaz administrativa cuando no haya variables de entorno. Esto conserva las reglas, invitaciones, permisos y el registro de auditoría para uso posterior.
+
+## Seguridad y operaciones
+
+- Mantén confidenciales y breves las invitaciones. Revoca los enlaces sin usar cuando cambie el destinatario.
+- Exige verificación de correo cuando la admisión dependa de una dirección o dominio aprobado. En modo de invitación, la posesión del enlace es la credencial; protégelo como un enlace de restablecimiento de contraseña.
+- Coloca límites de frecuencia y monitoreo en el proxy inverso o WAF para los endpoints públicos de registro e inicio de sesión. Las listas de IP no forman parte de la política de la aplicación y suelen ser demasiado generales para un despliegue reutilizable.
+- Usa HTTPS, un `SECRET_KEY` fuerte, cuentas administrativas controladas, respaldos y privilegios mínimos en la base de datos.
+- Trata la interfaz como orientación. La API aplica en el servidor la autorización administrativa, reglas de admisión, permisos y reserva de créditos.
+- La admisión no suspende cuentas existentes, asigna membresía de cursos, concede efectos de extensiones ni prueba la propiedad de una dirección de correo.
+
+La antigua instancia comunitaria pública de FAIR no está disponible actualmente y su disponibilidad futura no está garantizada. Estos controles son neutrales al despliegue y pueden ser usados por cualquier operador de FAIR.

--- a/docs/es/quickstart.md
+++ b/docs/es/quickstart.md
@@ -3,21 +3,18 @@ title: Inicio Rápido
 description: Cómo empezar con la Plataforma FAIR
 ---
 
-Esta página muestra la forma más rápida de comenzar a usar la **Plataforma FAIR**. Puedes probar nuestra instancia comunitaria en [platform.fairgradeproject.org](https://platform.fairgradeproject.org) o instalarla localmente en tu máquina. Ambas son, y siempre serán, completamente gratuitas.
+Esta página muestra la forma confiable más rápida de comenzar a usar la **Plataforma FAIR**: instalar la aplicación de código abierto localmente u operar tu propio despliegue.
 
 <Card
-title="Instancia Comunitaria"
-href="https://platform.fairgradeproject.org"
-arrow="true"
-cta="Explorar la instancia comunitaria"
+title="Estado de la instancia comunitaria pública"
 img="/assets/showcase.png"
 horizontal>
-Nuestra instancia comunitaria te permite explorar FAIR inmediatamente. Es la forma más rápida para educadores e investigadores de probar las funcionalidades sin necesidad de usar la terminal.
+La antigua instancia comunitaria pública de FAIR no está disponible actualmente. Es posible que se vuelva a desplegar en el futuro, pero su disponibilidad pública no está garantizada. Usa una instalación local o gestionada por un operador cuando necesites acceso confiable.
 </Card>
 
 ## ¿Qué debería usar?
-* La instancia comunitaria es perfecta para quienes quieren ver rápidamente la interfaz o comenzar a experimentar con las funcionalidades de inmediato.
-* La Instalación Local es ideal para instituciones que quieren control total sobre sus datos, o desarrolladores que buscan crear módulos personalizados y contribuir al proyecto.
+* Una instalación local es la vía disponible más rápida para evaluación, desarrollo e investigación reproducible.
+* Un despliegue gestionado por un operador es apropiado para instituciones que necesitan servicio duradero, registro controlado y límites explícitos de uso de IA.
 
 Para uso local, FAIR está diseñado para ser ligero: solo necesita un comando para instalar y un comando para ejecutar. No se requiere experiencia previa en programación.
 
@@ -65,7 +62,7 @@ Instalar FAIR es un proceso simple de tres pasos.
 
 
 ## La CLI
-El comando `fair` es tu punto de entrada para gestionar la plataforma. Puedes encontrar una lista completa de capacidades en nuestra [documentación de CLI](/en/cli).
+El comando `fair` es tu punto de entrada para gestionar la plataforma. Puedes encontrar una lista completa de capacidades en nuestra [documentación de CLI](/es/cli). Los operadores de instancias compartidas también deben revisar [Controles de admisión y costos de IA](/es/platform/access-controls).
 
 ## Solución de problemas
 Si algo no se ve correcto durante la instalación, consulta nuestra [guía de solución de problemas](/en/troubleshooting) o abre un issue en nuestro [GitHub](https://github.com/azapg/fair).

--- a/frontend-dev/src/app/chat/live-page.tsx
+++ b/frontend-dev/src/app/chat/live-page.tsx
@@ -21,6 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useMyAIEntitlement } from "@/hooks/use-access-controls";
 
 const noop = () => undefined;
 
@@ -63,15 +64,23 @@ const LiveMessageRow = React.memo(function LiveMessageRow({
 
 export default function LiveChatPage() {
   const capabilities = useCapabilities();
+  const entitlement = useMyAIEntitlement();
   const agentCapabilities = (capabilities.data ?? []).filter(
     (capability) => capability.surface === "chat.agent",
   );
   const [capabilityDefinitionId, setCapabilityDefinitionId] = React.useState("");
   React.useEffect(() => {
     if (!capabilityDefinitionId && agentCapabilities[0]) {
-      setCapabilityDefinitionId(agentCapabilities[0].id);
+      setCapabilityDefinitionId(
+        agentCapabilities.find((capability) => capability.costControl?.executable !== false)?.id
+          ?? agentCapabilities[0].id,
+      );
     }
   }, [agentCapabilities, capabilityDefinitionId]);
+  const selectedCapability = agentCapabilities.find(
+    (capability) => capability.id === capabilityDefinitionId,
+  );
+  const accessDenied = selectedCapability?.costControl?.executable === false;
   const live = useExecutionChat(capabilityDefinitionId || undefined);
   const pending = live.pendingInteraction;
   const isStreaming = live.status === "streaming";
@@ -107,6 +116,9 @@ export default function LiveChatPage() {
             <h1 className="text-sm font-semibold">FAIR live execution</h1>
             <p className="text-xs text-muted-foreground">
               {live.executionId ? `Execution ${live.executionId.slice(0, 8)} · ${live.status}` : "No active Execution"}
+              {entitlement.data?.controlsEnabled && entitlement.data.remainingUnits != null
+                ? ` · ${entitlement.data.remainingUnits} credits remaining`
+                : ""}
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -126,8 +138,9 @@ export default function LiveChatPage() {
               </SelectTrigger>
               <SelectContent>
                 {agentCapabilities.map((capability) => (
-                  <SelectItem key={capability.id} value={capability.id}>
+                  <SelectItem key={capability.id} value={capability.id} disabled={capability.costControl?.executable === false}>
                     {capability.displayName ?? capability.capabilityId} · {capability.version}
+                    {capability.costControl?.classification === "ai" ? ` · ${capability.costControl.costUnits} credits` : ""}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -186,11 +199,16 @@ export default function LiveChatPage() {
                   disabled={
                     isStreaming ||
                     Boolean(pending) ||
-                    !capabilityDefinitionId
+                    !capabilityDefinitionId ||
+                    accessDenied
                   }
                   placeholder={
                     pending
                       ? "Awaiting your response above…"
+                      : accessDenied
+                        ? selectedCapability?.costControl?.reason === "ai_quota_exhausted"
+                          ? "Monthly AI credits exhausted"
+                          : "AI access is not available for this capability"
                       : capabilityDefinitionId
                         ? "Ask the selected agent…"
                         : "Install or select an agent capability…"

--- a/frontend-dev/src/app/login/page.tsx
+++ b/frontend-dev/src/app/login/page.tsx
@@ -12,11 +12,13 @@ import { useTranslation } from 'react-i18next'
 import { IfSetting } from '@/components/if-setting'
 import { AuthPageShell } from '@/components/auth/auth-page-shell'
 import api from '@/lib/api'
+import { useSystemConfig } from '@/hooks/use-system-config'
 
 export default function LoginPage() {
   const navigate = useNavigate()
   const { login, loading } = useAuth()
   const { t } = useTranslation()
+  const systemConfig = useSystemConfig()
   const [email, setEmail] = React.useState('')
   const [password, setPassword] = React.useState('')
   const [rememberMe, setRememberMe] = React.useState(false)
@@ -149,14 +151,16 @@ export default function LoginPage() {
               </div>
             </Field>
           )}
-          <Field>
-            <FieldDescription className="text-center">
-              {t('auth.noAccount')}{' '}
-              <Link to="/register" className="underline underline-offset-4">
-                {t('auth.createOne')}
-              </Link>
-            </FieldDescription>
-          </Field>
+          {systemConfig.data?.registration.mode !== 'invite_only' && (
+            <Field>
+              <FieldDescription className="text-center">
+                {t('auth.noAccount')}{' '}
+                <Link to="/register" className="underline underline-offset-4">
+                  {t('auth.createOne')}
+                </Link>
+              </FieldDescription>
+            </Field>
+          )}
         </FieldGroup>
       </form>
     </AuthPageShell>

--- a/frontend-dev/src/app/register/page.tsx
+++ b/frontend-dev/src/app/register/page.tsx
@@ -9,21 +9,40 @@ import { AxiosError } from 'axios'
 import { useTranslation } from 'react-i18next'
 import { AuthPageShell } from '@/components/auth/auth-page-shell'
 import { ArrowLeft, ExternalLink, Mail } from 'lucide-react'
+import { useSystemConfig } from '@/hooks/use-system-config'
 
 export default function RegisterPage() {
   const navigate = useNavigate()
   const { register, loading } = useAuth()
   const { t } = useTranslation()
+  const systemConfig = useSystemConfig()
   const [name, setName] = React.useState('')
   const [email, setEmail] = React.useState('')
   const [password, setPassword] = React.useState('')
   const [verificationRequired, setVerificationRequired] = React.useState(false)
   const [verificationMessage, setVerificationMessage] = React.useState('')
+  const [inviteToken, setInviteToken] = React.useState('')
+
+  React.useEffect(() => {
+    const fragment = new URLSearchParams(window.location.hash.slice(1))
+    const token = fragment.get('invite')
+    if (!token) return
+    setInviteToken(token)
+    window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`)
+  }, [])
+
+  const registrationMode = systemConfig.data?.registration.mode ?? 'open'
+  const invitationRequired = registrationMode === 'invite_only'
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault()
     try {
-      const result = await register({ name, email, password })
+      const result = await register({
+        name,
+        email,
+        password,
+        inviteToken: inviteToken || undefined,
+      })
       if (result.verificationRequired) {
         setVerificationRequired(true)
         setVerificationMessage(result.detail ?? t('auth.verifyRegistrationDescription'))
@@ -96,7 +115,11 @@ export default function RegisterPage() {
           <div className="flex flex-col items-center gap-1 text-center">
             <h1 className="text-2xl font-bold">{t('auth.welcome')}</h1>
             <p className="text-sm text-balance text-muted-foreground">
-              {t('auth.createYourAccount')}
+              {registrationMode === 'allowlist'
+                ? t('auth.approvedEmailRegistration')
+                : invitationRequired
+                  ? t('auth.invitationRegistration')
+                  : t('auth.createYourAccount')}
             </p>
           </div>
           <Field>
@@ -138,8 +161,23 @@ export default function RegisterPage() {
               disabled={loading}
             />
           </Field>
+          {invitationRequired && (
+            <Field>
+              <FieldLabel htmlFor="invite-token">{t('auth.invitationCode')}</FieldLabel>
+              <Input
+                id="invite-token"
+                type="password"
+                autoComplete="off"
+                value={inviteToken}
+                onChange={(event) => setInviteToken(event.target.value)}
+                required
+                disabled={loading}
+              />
+              <FieldDescription>{t('auth.invitationCodeHint')}</FieldDescription>
+            </Field>
+          )}
           <Field>
-            <Button type="submit" disabled={loading} className="w-full">
+            <Button type="submit" disabled={loading || (invitationRequired && !inviteToken)} className="w-full">
               {loading ? t('common.wait') : t('auth.createAccount')}
             </Button>
           </Field>

--- a/frontend-dev/src/components/settings/sections/access-control-sections.test.tsx
+++ b/frontend-dev/src/components/settings/sections/access-control-sections.test.tsx
@@ -1,0 +1,77 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const updateCapability = vi.fn()
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        "settings.access.aiControls": "AI controls",
+        "settings.access.aiControlsDescription": "Control AI execution credits.",
+        "settings.access.enforceCredits": "Enforce credits",
+        "settings.access.weightedNotCurrency": "Credits are weights, not currency.",
+        "settings.access.unclassifiedWarning": "One capability is unclassified.",
+        "settings.access.capabilityCosts": "Capability costs",
+        "settings.access.capabilityCostsDescription": "Classify every capability.",
+        "settings.access.unclassified": "Unclassified",
+        "settings.access.unmetered": "Unmetered",
+        "settings.access.aiMetered": "AI metered",
+        "settings.access.classify": "Classify",
+        "settings.access.usageAudit": "Usage audit",
+        "settings.access.usageAuditDescription": "Review reservations.",
+        "settings.access.currentMonthCredits": "Current month credits",
+      })[key] ?? key,
+  }),
+}))
+
+vi.mock("@/hooks/use-access-controls", () => ({
+  usePlatformPolicy: () => ({
+    data: {
+      effectiveAiControlsEnabled: false,
+      aiControlsLocked: false,
+    },
+    isLoading: false,
+  }),
+  useUpdatePlatformPolicy: () => ({ mutate: vi.fn(), isPending: false }),
+  useCapabilityCostPolicies: () => ({
+    data: [
+      {
+        capabilityDefinitionId: "capability-1",
+        capabilityId: "agent.chat",
+        displayName: "Agent",
+        version: "1.0.0",
+        surface: "chat.agent",
+        extensionId: "example.agent",
+        classification: "unclassified",
+        costUnits: null,
+      },
+    ],
+    isLoading: false,
+  }),
+  useUpdateCapabilityCostPolicy: () => ({
+    mutate: updateCapability,
+    isPending: false,
+  }),
+  useAIUsage: () => ({
+    data: { totalUnits: 0, charges: [] },
+  }),
+}))
+
+import { AIControlsSection } from "./access-control-sections"
+
+afterEach(() => {
+  cleanup()
+  updateCapability.mockReset()
+})
+
+describe("AI control setup safety", () => {
+  it("keeps enforcement and classification submission disabled until an operator classifies the capability", () => {
+    render(<AIControlsSection />)
+
+    expect(screen.getByRole("switch", { name: "Enforce credits" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Classify" })).toBeDisabled()
+    expect(screen.getAllByText("Unclassified").length).toBeGreaterThan(0)
+    expect(updateCapability).not.toHaveBeenCalled()
+  })
+})

--- a/frontend-dev/src/components/settings/sections/access-control-sections.tsx
+++ b/frontend-dev/src/components/settings/sections/access-control-sections.tsx
@@ -1,0 +1,364 @@
+import * as React from "react";
+import { AxiosError } from "axios";
+import { Copy, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { SettingsSectionCard } from "@/components/settings/sections/settings-section-card";
+import {
+  type AIEntitlement,
+  type CapabilityCostPolicy,
+  useAdmissionRules,
+  useAIEntitlements,
+  useAIUsage,
+  useCapabilityCostPolicies,
+  useCreateAdmissionRule,
+  useCreateRegistrationInvite,
+  useDeleteAdmissionRule,
+  usePlatformPolicy,
+  useRegistrationInvites,
+  useRevokeRegistrationInvite,
+  useUpdateAIEntitlement,
+  useUpdateCapabilityCostPolicy,
+  useUpdatePlatformPolicy,
+} from "@/hooks/use-access-controls";
+
+function errorDescription(error: unknown) {
+  const axiosError = error as AxiosError<{ detail?: string }>;
+  return axiosError.response?.data?.detail ?? axiosError.message;
+}
+
+function reportFailure(error: unknown) {
+  toast.error("Unable to update access controls", { description: errorDescription(error) });
+}
+
+export function AdmissionSection() {
+  const { t } = useTranslation();
+  const policy = usePlatformPolicy();
+  const updatePolicy = useUpdatePlatformPolicy();
+  const rules = useAdmissionRules();
+  const createRule = useCreateAdmissionRule();
+  const deleteRule = useDeleteAdmissionRule();
+  const invites = useRegistrationInvites();
+  const createInvite = useCreateRegistrationInvite();
+  const revokeInvite = useRevokeRegistrationInvite();
+  const [ruleKind, setRuleKind] = React.useState<"email" | "domain">("domain");
+  const [ruleValue, setRuleValue] = React.useState("");
+  const [inviteEmail, setInviteEmail] = React.useState("");
+  const [lastInviteUrl, setLastInviteUrl] = React.useState<string | null>(null);
+
+  const mode = policy.data?.effectiveAdmissionMode ?? "open";
+  const closedWithoutRules = mode === "allowlist" && (rules.data?.length ?? 0) === 0;
+
+  return (
+    <div className="space-y-4">
+      <SettingsSectionCard
+        title={t("settings.access.admissionMode")}
+        description={t("settings.access.admissionModeDescription")}
+      >
+        <div className="flex flex-wrap items-center gap-3">
+          <Select
+            value={mode}
+            disabled={policy.isLoading || policy.data?.admissionLocked || updatePolicy.isPending}
+            onValueChange={(value: "open" | "allowlist" | "invite_only") =>
+              updatePolicy.mutate({ admissionMode: value }, { onError: reportFailure })
+            }
+          >
+            <SelectTrigger className="w-56"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="open">{t("settings.access.open")}</SelectItem>
+              <SelectItem value="allowlist">{t("settings.access.allowlist")}</SelectItem>
+              <SelectItem value="invite_only">{t("settings.access.inviteOnly")}</SelectItem>
+            </SelectContent>
+          </Select>
+          <Badge variant="outline">
+            {policy.data?.admissionSource === "environment"
+              ? t("settings.access.environmentLocked")
+              : t("settings.access.databaseManaged")}
+          </Badge>
+        </div>
+        {closedWithoutRules && (
+          <p className="text-sm text-destructive">{t("settings.access.emptyAllowlistWarning")}</p>
+        )}
+      </SettingsSectionCard>
+
+      <SettingsSectionCard
+        title={t("settings.access.approvedEmails")}
+        description={t("settings.access.approvedEmailsDescription")}
+      >
+        <form
+          className="flex flex-col gap-2 sm:flex-row"
+          onSubmit={(event) => {
+            event.preventDefault();
+            createRule.mutate(
+              { kind: ruleKind, value: ruleValue },
+              {
+                onSuccess: () => setRuleValue(""),
+                onError: reportFailure,
+              },
+            );
+          }}
+        >
+          <Select value={ruleKind} onValueChange={(value: "email" | "domain") => setRuleKind(value)}>
+            <SelectTrigger className="w-36"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="domain">{t("settings.access.domain")}</SelectItem>
+              <SelectItem value="email">{t("settings.access.emailAddress")}</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input
+            aria-label={t("settings.access.ruleValue")}
+            value={ruleValue}
+            onChange={(event) => setRuleValue(event.target.value)}
+            placeholder={ruleKind === "domain" ? "example.edu" : "person@example.edu"}
+            required
+          />
+          <Button type="submit" disabled={createRule.isPending}>{t("common.add")}</Button>
+        </form>
+        <div className="divide-y rounded-md border">
+          {(rules.data ?? []).map((rule) => (
+            <div key={rule.id} className="flex items-center justify-between gap-3 px-3 py-2 text-sm">
+              <span><Badge variant="secondary" className="mr-2">{rule.kind}</Badge>{rule.value}</span>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={t("common.delete")}
+                onClick={() => deleteRule.mutate(rule.id, { onError: reportFailure })}
+              ><Trash2 className="size-4" /></Button>
+            </div>
+          ))}
+          {!rules.isLoading && (rules.data?.length ?? 0) === 0 && (
+            <p className="p-3 text-sm text-muted-foreground">{t("settings.access.noRules")}</p>
+          )}
+        </div>
+      </SettingsSectionCard>
+
+      <SettingsSectionCard
+        title={t("settings.access.invitations")}
+        description={t("settings.access.invitationsDescription")}
+      >
+        <form
+          className="flex flex-col gap-2 sm:flex-row"
+          onSubmit={(event) => {
+            event.preventDefault();
+            createInvite.mutate(
+              { email: inviteEmail, expiresInDays: 7 },
+              {
+                onSuccess: (created) => {
+                  setInviteEmail("");
+                  setLastInviteUrl(created.registrationUrl);
+                },
+                onError: reportFailure,
+              },
+            );
+          }}
+        >
+          <Input
+            type="email"
+            value={inviteEmail}
+            onChange={(event) => setInviteEmail(event.target.value)}
+            placeholder="person@example.edu"
+            required
+          />
+          <Button type="submit" disabled={createInvite.isPending}>{t("settings.access.createInvite")}</Button>
+        </form>
+        {lastInviteUrl && (
+          <div className="rounded-md border border-primary/30 bg-primary/5 p-3">
+            <p className="mb-2 text-sm font-medium">{t("settings.access.copyInviteNow")}</p>
+            <div className="flex gap-2">
+              <Input readOnly value={lastInviteUrl} className="font-mono text-xs" />
+              <Button
+                variant="outline"
+                size="icon"
+                aria-label={t("settings.access.copyInvite")}
+                onClick={() => {
+                  void navigator.clipboard.writeText(lastInviteUrl);
+                  toast.success(t("settings.access.inviteCopied"));
+                }}
+              ><Copy className="size-4" /></Button>
+            </div>
+          </div>
+        )}
+        <div className="divide-y rounded-md border">
+          {(invites.data ?? []).map((invite) => (
+            <div key={invite.id} className="flex items-center justify-between gap-3 px-3 py-2 text-sm">
+              <div>
+                <p>{invite.email}</p>
+                <p className="text-xs text-muted-foreground">
+                  {invite.active ? t("settings.access.activeInvite") : t("settings.access.inactiveInvite")}
+                  {" · "}{new Date(invite.expiresAt).toLocaleDateString()}
+                </p>
+              </div>
+              {invite.active && (
+                <Button variant="outline" size="sm" onClick={() => revokeInvite.mutate(invite.id, { onError: reportFailure })}>
+                  {t("settings.access.revoke")}
+                </Button>
+              )}
+            </div>
+          ))}
+        </div>
+      </SettingsSectionCard>
+    </div>
+  );
+}
+
+function EntitlementRow({ entitlement }: { entitlement: AIEntitlement }) {
+  const { t } = useTranslation();
+  const update = useUpdateAIEntitlement();
+  const [state, setState] = React.useState(entitlement.state);
+  const [limit, setLimit] = React.useState(String(entitlement.monthlyLimitUnits ?? 100));
+
+  return (
+    <div className="grid gap-3 border-b px-3 py-3 last:border-b-0 lg:grid-cols-[minmax(12rem,1fr)_9rem_8rem_auto] lg:items-center">
+      <div><p className="font-medium">{entitlement.userName}</p><p className="text-xs text-muted-foreground">{entitlement.userEmail}</p></div>
+      <Select value={state} onValueChange={(value: AIEntitlement["state"]) => setState(value)}>
+        <SelectTrigger><SelectValue /></SelectTrigger>
+        <SelectContent>
+          <SelectItem value="disabled">{t("settings.access.disabled")}</SelectItem>
+          <SelectItem value="limited">{t("settings.access.limited")}</SelectItem>
+          <SelectItem value="unlimited">{t("settings.access.unlimited")}</SelectItem>
+        </SelectContent>
+      </Select>
+      <Input
+        type="number"
+        min={1}
+        aria-label={t("settings.access.monthlyCredits")}
+        value={limit}
+        disabled={state !== "limited"}
+        onChange={(event) => setLimit(event.target.value)}
+      />
+      <Button
+        size="sm"
+        disabled={update.isPending || (state === "limited" && Number(limit) < 1)}
+        onClick={() => update.mutate({
+          userId: entitlement.userId,
+          state,
+          monthlyLimitUnits: state === "limited" ? Number(limit) : null,
+        }, { onError: reportFailure })}
+      >{t("common.save")}</Button>
+      <p className="text-xs text-muted-foreground lg:col-start-2 lg:col-span-3">
+        {entitlement.usedUnits} {t("settings.access.creditsUsed")}
+        {entitlement.remainingUnits != null ? ` · ${entitlement.remainingUnits} ${t("settings.access.remaining")}` : ""}
+      </p>
+    </div>
+  );
+}
+
+export function AdminPeopleSection() {
+  const { t } = useTranslation();
+  const entitlements = useAIEntitlements();
+  return (
+    <SettingsSectionCard
+      title={t("settings.sections.adminPeople.title")}
+      description={t("settings.sections.adminPeople.description")}
+    >
+      <div className="overflow-hidden rounded-md border">
+        {(entitlements.data ?? []).map((entitlement) => <EntitlementRow key={entitlement.userId} entitlement={entitlement} />)}
+        {!entitlements.isLoading && (entitlements.data?.length ?? 0) === 0 && (
+          <p className="p-3 text-sm text-muted-foreground">{t("settings.access.noPeople")}</p>
+        )}
+      </div>
+    </SettingsSectionCard>
+  );
+}
+
+function CapabilityPolicyRow({ policy }: { policy: CapabilityCostPolicy }) {
+  const { t } = useTranslation();
+  const update = useUpdateCapabilityCostPolicy();
+  const [classification, setClassification] = React.useState<
+    "unclassified" | "unmetered" | "ai"
+  >(policy.classification);
+  const [cost, setCost] = React.useState(String(policy.costUnits ?? (classification === "ai" ? 1 : 0)));
+
+  return (
+    <div className="grid gap-3 border-b px-3 py-3 last:border-b-0 lg:grid-cols-[minmax(14rem,1fr)_10rem_7rem_auto] lg:items-center">
+      <div>
+        <p className="font-medium">{policy.displayName ?? policy.capabilityId}</p>
+        <p className="text-xs text-muted-foreground">{policy.extensionId} · {policy.version} · {policy.surface}</p>
+      </div>
+      <Select
+        value={classification}
+        onValueChange={(value: "unclassified" | "unmetered" | "ai") => {
+          setClassification(value);
+          setCost(value === "ai" ? String(Math.max(Number(cost) || 1, 1)) : "0");
+        }}
+      >
+        <SelectTrigger><SelectValue /></SelectTrigger>
+        <SelectContent>
+          <SelectItem value="unclassified" disabled>{t("settings.access.unclassified")}</SelectItem>
+          <SelectItem value="unmetered">{t("settings.access.unmetered")}</SelectItem>
+          <SelectItem value="ai">{t("settings.access.aiMetered")}</SelectItem>
+        </SelectContent>
+      </Select>
+      <Input type="number" min={classification === "ai" ? 1 : 0} disabled={classification !== "ai"} value={cost} onChange={(event) => setCost(event.target.value)} />
+      <Button
+        size="sm"
+        disabled={update.isPending || classification === "unclassified" || (classification === "ai" && Number(cost) < 1)}
+        onClick={() => {
+          if (classification === "unclassified") return;
+          update.mutate({ capabilityDefinitionId: policy.capabilityDefinitionId, classification, costUnits: classification === "ai" ? Number(cost) : 0 }, { onError: reportFailure });
+        }}
+      >{policy.classification === "unclassified" ? t("settings.access.classify") : t("common.save")}</Button>
+    </div>
+  );
+}
+
+export function AIControlsSection() {
+  const { t } = useTranslation();
+  const policy = usePlatformPolicy();
+  const updatePolicy = useUpdatePlatformPolicy();
+  const capabilities = useCapabilityCostPolicies();
+  const usage = useAIUsage();
+  const unclassified = (capabilities.data ?? []).filter((item) => item.classification === "unclassified").length;
+
+  return (
+    <div className="space-y-4">
+      <SettingsSectionCard title={t("settings.access.aiControls")} description={t("settings.access.aiControlsDescription")}>
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <Label htmlFor="ai-controls-enabled">{t("settings.access.enforceCredits")}</Label>
+            <p className="text-xs text-muted-foreground">{t("settings.access.weightedNotCurrency")}</p>
+          </div>
+          <Switch
+            id="ai-controls-enabled"
+            checked={policy.data?.effectiveAiControlsEnabled ?? false}
+            disabled={policy.isLoading || policy.data?.aiControlsLocked || updatePolicy.isPending || unclassified > 0}
+            onCheckedChange={(checked) => updatePolicy.mutate({ aiControlsEnabled: checked }, { onError: reportFailure })}
+          />
+        </div>
+        {unclassified > 0 && <p className="text-sm text-destructive">{t("settings.access.unclassifiedWarning", { count: unclassified })}</p>}
+      </SettingsSectionCard>
+
+      <SettingsSectionCard title={t("settings.access.capabilityCosts")} description={t("settings.access.capabilityCostsDescription")}>
+        <div className="overflow-hidden rounded-md border">
+          {(capabilities.data ?? []).map((item) => <CapabilityPolicyRow key={item.capabilityDefinitionId} policy={item} />)}
+          {!capabilities.isLoading && (capabilities.data?.length ?? 0) === 0 && <p className="p-3 text-sm text-muted-foreground">{t("settings.access.noCapabilities")}</p>}
+        </div>
+      </SettingsSectionCard>
+
+      <SettingsSectionCard title={t("settings.access.usageAudit")} description={t("settings.access.usageAuditDescription")}>
+        <p className="text-2xl font-semibold">{usage.data?.totalUnits ?? 0}</p>
+        <p className="text-xs text-muted-foreground">{t("settings.access.currentMonthCredits")}</p>
+        <div className="divide-y rounded-md border">
+          {(usage.data?.charges ?? []).slice(0, 10).map((charge) => (
+            <div key={charge.id} className="flex justify-between gap-3 px-3 py-2 text-xs">
+              <span>{charge.userEmail} · {charge.capabilityId}</span><span>{charge.units}</span>
+            </div>
+          ))}
+        </div>
+      </SettingsSectionCard>
+    </div>
+  );
+}

--- a/frontend-dev/src/components/settings/settings-sections.tsx
+++ b/frontend-dev/src/components/settings/settings-sections.tsx
@@ -4,6 +4,11 @@ import { AccountSection } from "@/components/settings/sections/account-section";
 import { EmptySectionFromKeys } from "@/components/settings/sections/empty-section";
 import { NotificationsSection } from "@/components/settings/sections/notifications-section";
 import { PreferencesSection } from "@/components/settings/sections/preferences-section";
+import {
+  AdmissionSection,
+  AdminPeopleSection,
+  AIControlsSection,
+} from "@/components/settings/sections/access-control-sections";
 
 export type SettingsCategoryId = "you" | "research" | "admin";
 
@@ -12,7 +17,9 @@ export type SettingsSectionId =
   | "preferences"
   | "notifications"
   | "api-keys"
-  | "admin-people";
+  | "admin-people"
+  | "admin-admission"
+  | "admin-ai";
 
 export type SettingsSectionDefinition = {
   id: SettingsSectionId;
@@ -64,11 +71,20 @@ export const SETTINGS_SECTIONS: SettingsSectionDefinition[] = [
     category: "admin",
     titleKey: "settings.sections.adminPeople.title",
     descriptionKey: "settings.sections.adminPeople.description",
-    render: () => (
-      <EmptySectionFromKeys
-        titleKey="settings.sections.adminPeople.title"
-        descriptionKey="settings.sections.adminPeople.description"
-      />
-    ),
+    render: AdminPeopleSection,
+  },
+  {
+    id: "admin-admission",
+    category: "admin",
+    titleKey: "settings.sections.adminAdmission.title",
+    descriptionKey: "settings.sections.adminAdmission.description",
+    render: AdmissionSection,
+  },
+  {
+    id: "admin-ai",
+    category: "admin",
+    titleKey: "settings.sections.adminAi.title",
+    descriptionKey: "settings.sections.adminAi.description",
+    render: AIControlsSection,
   },
 ];

--- a/frontend-dev/src/contexts/auth-context.tsx
+++ b/frontend-dev/src/contexts/auth-context.tsx
@@ -18,7 +18,7 @@ export type AuthUser = {
 }
 
 type LoginInput = { username: string; password: string; remember_me?: boolean }
-type RegisterInput = { name: string; email: string; password: string }
+type RegisterInput = { name: string; email: string; password: string; inviteToken?: string }
 export type RegisterResult = {
   verificationRequired: boolean
   detail?: string

--- a/frontend-dev/src/hooks/use-access-controls.ts
+++ b/frontend-dev/src/hooks/use-access-controls.ts
@@ -1,0 +1,191 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import api from "@/lib/api";
+
+export type PlatformPolicy = {
+  storedAdmissionMode: "open" | "allowlist" | "invite_only";
+  effectiveAdmissionMode: "open" | "allowlist" | "invite_only";
+  admissionSource: "database" | "environment";
+  admissionLocked: boolean;
+  storedAiControlsEnabled: boolean;
+  effectiveAiControlsEnabled: boolean;
+  aiControlsSource: "database" | "environment";
+  aiControlsLocked: boolean;
+};
+
+export type AdmissionRule = {
+  id: string;
+  kind: "email" | "domain";
+  value: string;
+  createdAt: string;
+};
+
+export type RegistrationInvite = {
+  id: string;
+  email: string;
+  expiresAt: string;
+  redeemedAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+  active: boolean;
+};
+
+export type InviteSecret = RegistrationInvite & {
+  token: string;
+  registrationUrl: string;
+};
+
+export type CapabilityCostPolicy = {
+  capabilityDefinitionId: string;
+  capabilityId: string;
+  displayName: string | null;
+  version: string;
+  surface: string;
+  extensionId: string;
+  classification: "unclassified" | "unmetered" | "ai";
+  costUnits: number | null;
+};
+
+export type AIEntitlement = {
+  userId: string;
+  userName: string;
+  userEmail: string;
+  state: "disabled" | "limited" | "unlimited";
+  monthlyLimitUnits: number | null;
+  usedUnits: number;
+  remainingUnits: number | null;
+  periodStart: string;
+  nextResetAt: string;
+  controlsEnabled: boolean;
+};
+
+export type AIUsage = {
+  periodStart: string;
+  totalUnits: number;
+  charges: Array<{
+    id: string;
+    executionId: string;
+    userEmail: string;
+    capabilityId: string;
+    units: number;
+    createdAt: string;
+  }>;
+};
+
+const keys = {
+  policy: ["access-controls", "policy"] as const,
+  rules: ["access-controls", "rules"] as const,
+  invites: ["access-controls", "invites"] as const,
+  capabilities: ["access-controls", "capabilities"] as const,
+  entitlements: ["access-controls", "entitlements"] as const,
+  usage: ["access-controls", "usage"] as const,
+  mine: ["access-controls", "mine"] as const,
+};
+
+export function usePlatformPolicy() {
+  return useQuery({ queryKey: keys.policy, queryFn: async () => (await api.get("/v1/admin/platform-policy")).data as PlatformPolicy });
+}
+
+export function useUpdatePlatformPolicy() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: { admissionMode?: PlatformPolicy["effectiveAdmissionMode"]; aiControlsEnabled?: boolean }) =>
+      (await api.patch("/v1/admin/platform-policy", payload)).data as PlatformPolicy,
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: keys.policy });
+      client.invalidateQueries({ queryKey: ["system-config"] });
+    },
+  });
+}
+
+export function useAdmissionRules() {
+  return useQuery({ queryKey: keys.rules, queryFn: async () => (await api.get("/v1/admin/admission-rules")).data as AdmissionRule[] });
+}
+
+export function useCreateAdmissionRule() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: { kind: "email" | "domain"; value: string }) =>
+      (await api.post("/v1/admin/admission-rules", payload)).data as AdmissionRule,
+    onSuccess: () => client.invalidateQueries({ queryKey: keys.rules }),
+  });
+}
+
+export function useDeleteAdmissionRule() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => api.delete(`/v1/admin/admission-rules/${id}`),
+    onSuccess: () => client.invalidateQueries({ queryKey: keys.rules }),
+  });
+}
+
+export function useRegistrationInvites() {
+  return useQuery({ queryKey: keys.invites, queryFn: async () => (await api.get("/v1/admin/invites")).data as RegistrationInvite[] });
+}
+
+export function useCreateRegistrationInvite() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: { email: string; expiresInDays: number }) =>
+      (await api.post("/v1/admin/invites", payload)).data as InviteSecret,
+    onSuccess: () => client.invalidateQueries({ queryKey: keys.invites }),
+  });
+}
+
+export function useRevokeRegistrationInvite() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => (await api.post(`/v1/admin/invites/${id}/revoke`)).data,
+    onSuccess: () => client.invalidateQueries({ queryKey: keys.invites }),
+  });
+}
+
+export function useCapabilityCostPolicies() {
+  return useQuery({ queryKey: keys.capabilities, queryFn: async () => (await api.get("/v1/admin/capability-cost-policies")).data as CapabilityCostPolicy[] });
+}
+
+export function useUpdateCapabilityCostPolicy() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: { capabilityDefinitionId: string; classification: "unmetered" | "ai"; costUnits: number }) =>
+      (await api.put(`/v1/admin/capability-cost-policies/${payload.capabilityDefinitionId}`, {
+        classification: payload.classification,
+        costUnits: payload.costUnits,
+      })).data as CapabilityCostPolicy,
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: keys.capabilities });
+      client.invalidateQueries({ queryKey: ["extensions", "capabilities"] });
+    },
+  });
+}
+
+export function useAIEntitlements() {
+  return useQuery({ queryKey: keys.entitlements, queryFn: async () => (await api.get("/v1/admin/ai-entitlements")).data as AIEntitlement[] });
+}
+
+export function useUpdateAIEntitlement() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: { userId: string; state: AIEntitlement["state"]; monthlyLimitUnits: number | null }) =>
+      (await api.put(`/v1/admin/users/${payload.userId}/ai-entitlement`, {
+        state: payload.state,
+        monthlyLimitUnits: payload.monthlyLimitUnits,
+      })).data as AIEntitlement,
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: keys.entitlements });
+      client.invalidateQueries({ queryKey: keys.mine });
+    },
+  });
+}
+
+export function useAIUsage() {
+  return useQuery({ queryKey: keys.usage, queryFn: async () => (await api.get("/v1/admin/ai-usage")).data as AIUsage });
+}
+
+export function useMyAIEntitlement(enabled = true) {
+  return useQuery({
+    queryKey: keys.mine,
+    queryFn: async () => (await api.get("/v1/ai/entitlement")).data as Omit<AIEntitlement, "userId" | "userName" | "userEmail">,
+    enabled,
+  });
+}

--- a/frontend-dev/src/hooks/use-extensions.ts
+++ b/frontend-dev/src/hooks/use-extensions.ts
@@ -33,6 +33,13 @@ export type CapabilityDefinition = {
   supportsStreaming: boolean;
   supportsCancellation: boolean;
   supportsResume: boolean;
+  costControl?: {
+    controlsEnabled: boolean;
+    classification: "unclassified" | "unmetered" | "ai";
+    costUnits: number | null;
+    executable: boolean;
+    reason: "ai_policy_unconfigured" | "ai_not_entitled" | "ai_quota_exhausted" | null;
+  } | null;
 };
 
 export type CreateExtensionInput = {

--- a/frontend-dev/src/hooks/use-system-config.ts
+++ b/frontend-dev/src/hooks/use-system-config.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+
+import api from "@/lib/api";
+
+export type SystemConfig = {
+  features: {
+    email_enabled: boolean;
+    ai_controls_enabled: boolean;
+  };
+  registration: {
+    mode: "open" | "allowlist" | "invite_only";
+    invite_required: boolean;
+  };
+};
+
+export function useSystemConfig() {
+  return useQuery({
+    queryKey: ["system-config"],
+    queryFn: async (): Promise<SystemConfig> => {
+      const response = await api.get("/v1/system/config");
+      return response.data;
+    },
+    staleTime: 30_000,
+  });
+}

--- a/frontend-dev/src/i18n/locales/en.json
+++ b/frontend-dev/src/i18n/locales/en.json
@@ -183,12 +183,68 @@
       },
       "adminPeople": {
         "title": "People",
-        "description": "Manage members and administrative access."
+        "description": "Assign per-user AI access and monthly weighted credits."
+      },
+      "adminAdmission": {
+        "title": "Admission",
+        "description": "Control who may create a FAIR account."
+      },
+      "adminAi": {
+        "title": "AI controls",
+        "description": "Classify costly capabilities, enforce credits, and audit usage."
       },
       "adminModels": {
         "title": "Models",
         "description": "Control organization-level model policies."
       }
+    },
+    "access": {
+      "admissionMode": "Registration admission",
+      "admissionModeDescription": "Admission applies to new account registration only. Existing accounts can still sign in.",
+      "open": "Open registration",
+      "allowlist": "Approved emails",
+      "inviteOnly": "Invitation only",
+      "environmentLocked": "Locked by environment",
+      "databaseManaged": "Managed here",
+      "emptyAllowlistWarning": "No one can register until at least one approved email or domain is added.",
+      "approvedEmails": "Approved emails and domains",
+      "approvedEmailsDescription": "Domains match exactly; add subdomains separately.",
+      "domain": "Domain",
+      "emailAddress": "Email",
+      "ruleValue": "Approved value",
+      "noRules": "No approval rules configured.",
+      "invitations": "Registration invitations",
+      "invitationsDescription": "Email-bound, single-use links expire after seven days. The secret is shown once.",
+      "createInvite": "Create invitation",
+      "copyInviteNow": "Copy this link now. It cannot be shown again.",
+      "copyInvite": "Copy invitation link",
+      "inviteCopied": "Invitation link copied",
+      "activeInvite": "Active",
+      "inactiveInvite": "Used, revoked, or expired",
+      "revoke": "Revoke",
+      "disabled": "Disabled",
+      "limited": "Limited",
+      "unlimited": "Unlimited",
+      "monthlyCredits": "Monthly credits",
+      "creditsUsed": "credits used",
+      "remaining": "remaining",
+      "noPeople": "No users found.",
+      "aiControls": "AI credit enforcement",
+      "aiControlsDescription": "Admission does not grant AI access. Entitlements and capability weights are enforced separately.",
+      "enforceCredits": "Enforce weighted execution credits",
+      "weightedNotCurrency": "Credits limit accepted FAIR executions; they are not a provider-currency ceiling.",
+      "unclassifiedWarning_one": "Classify {{count}} capability before enabling enforcement.",
+      "unclassifiedWarning_other": "Classify {{count}} capabilities before enabling enforcement.",
+      "capabilityCosts": "Capability classification",
+      "capabilityCostsDescription": "Every installed capability version must be classified. New versions fail closed when enforcement is on.",
+      "unmetered": "Unmetered",
+      "unclassified": "Unclassified",
+      "aiMetered": "AI metered",
+      "classify": "Classify",
+      "noCapabilities": "No installed capabilities.",
+      "usageAudit": "Usage audit",
+      "usageAuditDescription": "Immutable charges for accepted metered executions.",
+      "currentMonthCredits": "weighted credits accepted this UTC month"
     }
   },
   "auth": {
@@ -196,6 +252,10 @@
     "loginToFair": "Login to The Fair Platform",
     "welcome": "Welcome",
     "createYourAccount": "Create your account",
+    "approvedEmailRegistration": "Registration is limited to approved email addresses.",
+    "invitationRegistration": "A registration invitation is required.",
+    "invitationCode": "Invitation code",
+    "invitationCodeHint": "Open the invitation link from your administrator or paste its code here.",
     "email": "Email",
     "password": "Password",
     "name": "Name",

--- a/frontend-dev/src/i18n/locales/es.json
+++ b/frontend-dev/src/i18n/locales/es.json
@@ -183,12 +183,68 @@
       },
       "adminPeople": {
         "title": "Personas",
-        "description": "Administra miembros y acceso administrativo."
+        "description": "Asigna acceso a IA y créditos ponderados mensuales por usuario."
+      },
+      "adminAdmission": {
+        "title": "Admisión",
+        "description": "Controla quién puede crear una cuenta de FAIR."
+      },
+      "adminAi": {
+        "title": "Controles de IA",
+        "description": "Clasifica capacidades costosas, aplica créditos y audita el uso."
       },
       "adminModels": {
         "title": "Modelos",
         "description": "Controla políticas de modelos a nivel organización."
       }
+    },
+    "access": {
+      "admissionMode": "Admisión de registros",
+      "admissionModeDescription": "La admisión solo aplica al registro de cuentas nuevas. Las cuentas existentes pueden seguir iniciando sesión.",
+      "open": "Registro abierto",
+      "allowlist": "Correos aprobados",
+      "inviteOnly": "Solo por invitación",
+      "environmentLocked": "Bloqueado por el entorno",
+      "databaseManaged": "Administrado aquí",
+      "emptyAllowlistWarning": "Nadie podrá registrarse hasta agregar al menos un correo o dominio aprobado.",
+      "approvedEmails": "Correos y dominios aprobados",
+      "approvedEmailsDescription": "Los dominios coinciden de forma exacta; agrega los subdominios por separado.",
+      "domain": "Dominio",
+      "emailAddress": "Correo",
+      "ruleValue": "Valor aprobado",
+      "noRules": "No hay reglas de aprobación configuradas.",
+      "invitations": "Invitaciones de registro",
+      "invitationsDescription": "Los enlaces están ligados al correo, son de un solo uso y vencen en siete días. El secreto se muestra una vez.",
+      "createInvite": "Crear invitación",
+      "copyInviteNow": "Copia este enlace ahora. No podrá mostrarse nuevamente.",
+      "copyInvite": "Copiar enlace de invitación",
+      "inviteCopied": "Enlace de invitación copiado",
+      "activeInvite": "Activa",
+      "inactiveInvite": "Usada, revocada o vencida",
+      "revoke": "Revocar",
+      "disabled": "Deshabilitado",
+      "limited": "Limitado",
+      "unlimited": "Ilimitado",
+      "monthlyCredits": "Créditos mensuales",
+      "creditsUsed": "créditos usados",
+      "remaining": "restantes",
+      "noPeople": "No se encontraron usuarios.",
+      "aiControls": "Aplicación de créditos de IA",
+      "aiControlsDescription": "La admisión no concede acceso a IA. Los derechos y pesos de capacidad se aplican por separado.",
+      "enforceCredits": "Aplicar créditos ponderados por ejecución",
+      "weightedNotCurrency": "Los créditos limitan ejecuciones aceptadas por FAIR; no son un límite monetario del proveedor.",
+      "unclassifiedWarning_one": "Clasifica {{count}} capacidad antes de activar la aplicación.",
+      "unclassifiedWarning_other": "Clasifica {{count}} capacidades antes de activar la aplicación.",
+      "capabilityCosts": "Clasificación de capacidades",
+      "capabilityCostsDescription": "Cada versión instalada debe clasificarse. Las versiones nuevas se bloquean si la aplicación está activa.",
+      "unmetered": "Sin medición",
+      "unclassified": "Sin clasificar",
+      "aiMetered": "IA medida",
+      "classify": "Clasificar",
+      "noCapabilities": "No hay capacidades instaladas.",
+      "usageAudit": "Auditoría de uso",
+      "usageAuditDescription": "Cargos inmutables por ejecuciones medidas aceptadas.",
+      "currentMonthCredits": "créditos ponderados aceptados este mes UTC"
     }
   },
   "auth": {
@@ -196,6 +252,10 @@
     "loginToFair": "Inicia sesión en The Fair Platform",
     "welcome": "Bienvenido",
     "createYourAccount": "Crea tu cuenta",
+    "approvedEmailRegistration": "El registro está limitado a correos aprobados.",
+    "invitationRegistration": "Se requiere una invitación de registro.",
+    "invitationCode": "Código de invitación",
+    "invitationCodeHint": "Abre el enlace de tu administrador o pega aquí su código.",
     "email": "Correo electrónico",
     "password": "Contraseña",
     "name": "Nombre",

--- a/src/fair_platform/backend/alembic/versions/20260823_0035_admission_ai_controls.py
+++ b/src/fair_platform/backend/alembic/versions/20260823_0035_admission_ai_controls.py
@@ -1,0 +1,293 @@
+"""Add registration admission and AI weighted-credit controls.
+
+Revision ID: 20260823_0035
+Revises: 20260812_0034
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260823_0035"
+down_revision: str = "20260812_0034"
+branch_labels = None
+depends_on = None
+
+
+def _normalize_email(value: str) -> str:
+    address = value.strip()
+    local, separator, domain = address.rpartition("@")
+    if not separator or not local or not domain:
+        raise ValueError("invalid email address")
+    return f"{local.casefold()}@{domain.encode('idna').decode('ascii').casefold()}"
+
+
+def _preflight_user_emails(connection) -> list[tuple[Any, str]]:
+    users = sa.table(
+        "users",
+        sa.column("id", sa.UUID()),
+        sa.column("email", sa.String()),
+    )
+    normalized_rows: list[tuple[Any, str]] = []
+    invalid: list[str] = []
+    collisions: defaultdict[str, list[str]] = defaultdict(list)
+    for row in connection.execute(sa.select(users.c.id, users.c.email)).mappings():
+        try:
+            normalized = _normalize_email(str(row["email"]))
+        except (ValueError, UnicodeError):
+            invalid.append(str(row["id"]))
+            continue
+        normalized_rows.append((row["id"], normalized))
+        collisions[normalized].append(str(row["id"]))
+
+    duplicate_groups = {email: ids for email, ids in collisions.items() if len(ids) > 1}
+    if invalid or duplicate_groups:
+        problems = []
+        if invalid:
+            preview = ", ".join(invalid[:10])
+            problems.append(f"invalid email rows: {preview}")
+        if duplicate_groups:
+            preview = "; ".join(
+                f"{email}: {', '.join(ids)}"
+                for email, ids in list(duplicate_groups.items())[:10]
+            )
+            problems.append(f"normalized email collisions: {preview}")
+        raise RuntimeError(
+            "Cannot enable canonical user identities. Resolve "
+            + " | ".join(problems)
+            + " and rerun the migration; FAIR will not merge or delete accounts automatically."
+        )
+    return normalized_rows
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    normalized_rows = _preflight_user_emails(connection)
+
+    op.add_column("users", sa.Column("normalized_email", sa.String(320), nullable=True))
+    users = sa.table(
+        "users",
+        sa.column("id", sa.UUID()),
+        sa.column("normalized_email", sa.String(320)),
+    )
+    for user_id, normalized in normalized_rows:
+        connection.execute(
+            users.update()
+            .where(users.c.id == user_id)
+            .values(normalized_email=normalized)
+        )
+    with op.batch_alter_table("users") as batch:
+        batch.alter_column(
+            "normalized_email",
+            existing_type=sa.String(320),
+            nullable=False,
+        )
+        batch.create_unique_constraint(
+            "uq_users_normalized_email", ["normalized_email"]
+        )
+
+    op.create_table(
+        "platform_policies",
+        sa.Column("id", sa.SmallInteger(), nullable=False),
+        sa.Column(
+            "admission_mode", sa.String(32), nullable=False, server_default="open"
+        ),
+        sa.Column(
+            "ai_controls_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("updated_by_user_id", sa.UUID(), nullable=True),
+        sa.CheckConstraint("id = 1", name="ck_platform_policy_singleton"),
+        sa.CheckConstraint(
+            "admission_mode IN ('open', 'allowlist', 'invite_only')",
+            name="ck_platform_policy_admission_mode",
+        ),
+        sa.ForeignKeyConstraint(
+            ["updated_by_user_id"], ["users.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "admission_rules",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("kind", sa.String(16), nullable=False),
+        sa.Column("normalized_value", sa.String(320), nullable=False),
+        sa.Column("created_by_user_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_user_id"], ["users.id"], ondelete="RESTRICT"
+        ),
+        sa.CheckConstraint(
+            "kind IN ('email', 'domain')", name="ck_admission_rule_kind"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("kind", "normalized_value", name="uq_admission_rule_value"),
+    )
+    op.create_index(
+        "ix_admission_rules_kind_value",
+        "admission_rules",
+        ["kind", "normalized_value"],
+    )
+    op.create_table(
+        "registration_invites",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("token_hash", sa.String(64), nullable=False),
+        sa.Column("normalized_email", sa.String(320), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("redeemed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("redeemed_by_user_id", sa.UUID(), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_by_user_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_user_id"], ["users.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(
+            ["redeemed_by_user_id"], ["users.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash", name="uq_registration_invites_token_hash"),
+    )
+    op.create_index(
+        "ix_registration_invites_email",
+        "registration_invites",
+        ["normalized_email", "expires_at"],
+    )
+    op.create_table(
+        "ai_capability_policies",
+        sa.Column("capability_definition_id", sa.UUID(), nullable=False),
+        sa.Column("classification", sa.String(16), nullable=False),
+        sa.Column("cost_units", sa.Integer(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("updated_by_user_id", sa.UUID(), nullable=False),
+        sa.CheckConstraint("cost_units >= 0", name="ck_ai_capability_cost_nonnegative"),
+        sa.CheckConstraint(
+            "(classification = 'unmetered' AND cost_units = 0) OR "
+            "(classification = 'ai' AND cost_units > 0)",
+            name="ck_ai_capability_classification_cost",
+        ),
+        sa.CheckConstraint(
+            "classification IN ('unmetered', 'ai')",
+            name="ck_ai_capability_classification",
+        ),
+        sa.ForeignKeyConstraint(
+            ["capability_definition_id"],
+            ["capability_definitions.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["updated_by_user_id"], ["users.id"], ondelete="RESTRICT"
+        ),
+        sa.PrimaryKeyConstraint("capability_definition_id"),
+    )
+    op.create_table(
+        "ai_entitlements",
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("state", sa.String(16), nullable=False, server_default="disabled"),
+        sa.Column("monthly_limit_units", sa.Integer(), nullable=True),
+        sa.Column("used_units", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("period_start", sa.Date(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("updated_by_user_id", sa.UUID(), nullable=False),
+        sa.CheckConstraint(
+            "used_units >= 0", name="ck_ai_entitlement_used_nonnegative"
+        ),
+        sa.CheckConstraint(
+            "monthly_limit_units IS NULL OR monthly_limit_units > 0",
+            name="ck_ai_entitlement_limit_positive",
+        ),
+        sa.CheckConstraint(
+            "(state = 'limited' AND monthly_limit_units IS NOT NULL) OR "
+            "(state != 'limited' AND monthly_limit_units IS NULL)",
+            name="ck_ai_entitlement_state_limit",
+        ),
+        sa.CheckConstraint(
+            "state IN ('disabled', 'limited', 'unlimited')",
+            name="ck_ai_entitlement_state",
+        ),
+        sa.ForeignKeyConstraint(
+            ["updated_by_user_id"], ["users.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id"),
+    )
+    op.create_table(
+        "ai_usage_charges",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("execution_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("capability_definition_id", sa.UUID(), nullable=False),
+        sa.Column("units", sa.Integer(), nullable=False),
+        sa.Column("period_start", sa.Date(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint("units > 0", name="ck_ai_usage_charge_units_positive"),
+        sa.ForeignKeyConstraint(
+            ["capability_definition_id"],
+            ["capability_definitions.id"],
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["execution_id"], ["executions.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("execution_id", name="uq_ai_usage_charges_execution_id"),
+    )
+    op.create_index(
+        "ix_ai_usage_user_period",
+        "ai_usage_charges",
+        ["user_id", "period_start", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ai_usage_user_period", table_name="ai_usage_charges")
+    op.drop_table("ai_usage_charges")
+    op.drop_table("ai_entitlements")
+    op.drop_table("ai_capability_policies")
+    op.drop_index("ix_registration_invites_email", table_name="registration_invites")
+    op.drop_table("registration_invites")
+    op.drop_index("ix_admission_rules_kind_value", table_name="admission_rules")
+    op.drop_table("admission_rules")
+    op.drop_table("platform_policies")
+    with op.batch_alter_table("users") as batch:
+        batch.drop_constraint("uq_users_normalized_email", type_="unique")
+        batch.drop_column("normalized_email")

--- a/src/fair_platform/backend/api/routers/admin_access.py
+++ b/src/fair_platform/backend/api/routers/admin_access.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from fair_platform.backend.api.routers.auth import get_current_user
+from fair_platform.backend.api.schema.access_control import (
+    AdmissionRuleCreate,
+    AdmissionRuleRead,
+    AIEntitlementRead,
+    AIEntitlementUpdate,
+    AIUsageChargeRead,
+    AIUsageRead,
+    CapabilityCostPolicyRead,
+    CapabilityCostPolicyUpdate,
+    InviteCreate,
+    InviteRead,
+    InviteSecretRead,
+    PlatformPolicyRead,
+    PlatformPolicyUpdate,
+    SelfAIEntitlementRead,
+)
+from fair_platform.backend.core.config import (
+    get_admission_mode_override,
+    get_ai_controls_enabled_override,
+    get_base_url,
+)
+from fair_platform.backend.core.security.permissions import has_capability
+from fair_platform.backend.data.database import session_dependency
+from fair_platform.backend.data.models import (
+    AdmissionMode,
+    AdmissionRule,
+    AdmissionRuleKind,
+    AICapabilityPolicy,
+    AIEntitlement,
+    AIEntitlementState,
+    AIUsageCharge,
+    CapabilityDefinition,
+    ExtensionInstallation,
+    RegistrationInvite,
+    User,
+)
+from fair_platform.backend.data.models.access_control import AICapabilityClassification
+from fair_platform.backend.services.access_control import (
+    create_registration_invite,
+    entitlement_payload,
+    get_or_create_platform_policy,
+    normalize_admission_rule,
+    read_platform_policy,
+    resolve_platform_policy,
+    usage_total_for_period,
+    utc_month_start,
+)
+
+
+router = APIRouter()
+self_router = APIRouter()
+
+
+def _value(value: object) -> str:
+    return value.value if hasattr(value, "value") else str(value)
+
+
+def _require_admin(user: User) -> None:
+    if not has_capability(user, "admin"):
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+
+def _policy_read(db: Session) -> PlatformPolicyRead:
+    stored = read_platform_policy(db)
+    effective = resolve_platform_policy(db)
+    return PlatformPolicyRead(
+        stored_admission_mode=(
+            _value(stored.admission_mode) if stored else AdmissionMode.open.value
+        ),
+        effective_admission_mode=effective.admission_mode.value,
+        admission_source=effective.admission_source,
+        admission_locked=effective.admission_source == "environment",
+        stored_ai_controls_enabled=(
+            bool(stored.ai_controls_enabled) if stored else False
+        ),
+        effective_ai_controls_enabled=effective.ai_controls_enabled,
+        ai_controls_source=effective.ai_controls_source,
+        ai_controls_locked=effective.ai_controls_source == "environment",
+        updated_at=stored.updated_at if stored else None,
+    )
+
+
+@router.get("/platform-policy", response_model=PlatformPolicyRead)
+def read_policy(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> PlatformPolicyRead:
+    _require_admin(current_user)
+    return _policy_read(db)
+
+
+@router.patch("/platform-policy", response_model=PlatformPolicyRead)
+def update_policy(
+    payload: PlatformPolicyUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+) -> PlatformPolicyRead:
+    _require_admin(current_user)
+    if payload.admission_mode is not None and get_admission_mode_override() is not None:
+        raise HTTPException(
+            status_code=409, detail="Admission mode is locked by the environment"
+        )
+    if (
+        payload.ai_controls_enabled is not None
+        and get_ai_controls_enabled_override() is not None
+    ):
+        raise HTTPException(
+            status_code=409, detail="AI controls are locked by the environment"
+        )
+    if payload.ai_controls_enabled is True:
+        unclassified = int(
+            db.scalar(
+                select(func.count())
+                .select_from(CapabilityDefinition)
+                .outerjoin(
+                    AICapabilityPolicy,
+                    AICapabilityPolicy.capability_definition_id
+                    == CapabilityDefinition.id,
+                )
+                .where(AICapabilityPolicy.capability_definition_id.is_(None))
+            )
+            or 0
+        )
+        if unclassified:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Classify all capabilities before enabling AI controls "
+                    f"({unclassified} unclassified)"
+                ),
+            )
+    row = get_or_create_platform_policy(db)
+    if payload.admission_mode is not None:
+        row.admission_mode = AdmissionMode(payload.admission_mode)
+    if payload.ai_controls_enabled is not None:
+        row.ai_controls_enabled = payload.ai_controls_enabled
+    row.updated_by_user_id = current_user.id
+    db.commit()
+    db.refresh(row)
+    return _policy_read(db)
+
+
+@router.get("/admission-rules", response_model=list[AdmissionRuleRead])
+def list_admission_rules(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+):
+    _require_admin(current_user)
+    rows = db.scalars(
+        select(AdmissionRule).order_by(
+            AdmissionRule.kind, AdmissionRule.normalized_value
+        )
+    )
+    return [
+        AdmissionRuleRead(
+            id=row.id,
+            kind=_value(row.kind),
+            value=row.normalized_value,
+            created_at=row.created_at,
+        )
+        for row in rows
+    ]
+
+
+@router.post("/admission-rules", response_model=AdmissionRuleRead, status_code=201)
+def create_admission_rule(
+    payload: AdmissionRuleCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+):
+    _require_admin(current_user)
+    try:
+        normalized = normalize_admission_rule(payload.kind, payload.value)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    row = AdmissionRule(
+        kind=AdmissionRuleKind(payload.kind),
+        normalized_value=normalized,
+        created_by_user_id=current_user.id,
+    )
+    db.add(row)
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=409, detail="Admission rule already exists"
+        ) from exc
+    db.refresh(row)
+    return AdmissionRuleRead(
+        id=row.id, kind=payload.kind, value=normalized, created_at=row.created_at
+    )
+
+
+@router.delete("/admission-rules/{rule_id}", status_code=204)
+def delete_admission_rule(
+    rule_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+):
+    _require_admin(current_user)
+    row = db.get(AdmissionRule, rule_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Admission rule not found")
+    db.delete(row)
+    db.commit()
+
+
+def _invite_read(row, *, token: str | None = None):
+    now = datetime.now(timezone.utc)
+    expires_at = (
+        row.expires_at.replace(tzinfo=timezone.utc)
+        if row.expires_at.tzinfo is None
+        else row.expires_at
+    )
+    values = dict(
+        id=row.id,
+        email=row.normalized_email,
+        expires_at=row.expires_at,
+        redeemed_at=row.redeemed_at,
+        revoked_at=row.revoked_at,
+        created_at=row.created_at,
+        active=(
+            row.redeemed_at is None and row.revoked_at is None and expires_at > now
+        ),
+    )
+    if token is None:
+        return InviteRead(**values)
+    return InviteSecretRead(
+        **values,
+        token=token,
+        registration_url=f"{get_base_url()}/register#invite={token}",
+    )
+
+
+@router.get("/invites", response_model=list[InviteRead])
+def list_invites(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+):
+    _require_admin(current_user)
+    rows = db.scalars(
+        select(RegistrationInvite).order_by(RegistrationInvite.created_at.desc())
+    )
+    return [_invite_read(row) for row in rows]
+
+
+@router.post("/invites", response_model=InviteSecretRead, status_code=201)
+def create_invite(
+    payload: InviteCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+):
+    _require_admin(current_user)
+    row, token = create_registration_invite(
+        db,
+        email=str(payload.email),
+        created_by_user_id=current_user.id,
+        expires_in_days=payload.expires_in_days,
+    )
+    db.commit()
+    db.refresh(row)
+    return _invite_read(row, token=token)
+
+
+@router.post("/invites/{invite_id}/revoke", response_model=InviteRead)
+def revoke_invite(
+    invite_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+):
+    _require_admin(current_user)
+    row = db.get(RegistrationInvite, invite_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Invitation not found")
+    if row.redeemed_at is not None:
+        raise HTTPException(
+            status_code=409, detail="A redeemed invitation cannot be revoked"
+        )
+    if row.revoked_at is None:
+        row.revoked_at = datetime.now(timezone.utc)
+        db.commit()
+        db.refresh(row)
+    return _invite_read(row)
+
+
+def _capability_policy_read(capability, installation, policy):
+    return CapabilityCostPolicyRead(
+        capability_definition_id=capability.id,
+        capability_id=capability.capability_id,
+        display_name=capability.display_name,
+        version=capability.version,
+        surface=capability.surface,
+        extension_id=installation.extension_id,
+        classification=_value(policy.classification) if policy else "unclassified",
+        cost_units=policy.cost_units if policy else None,
+        updated_at=policy.updated_at if policy else None,
+    )
+
+
+@router.get("/capability-cost-policies", response_model=list[CapabilityCostPolicyRead])
+def list_capability_cost_policies(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+):
+    _require_admin(current_user)
+    rows = db.execute(
+        select(CapabilityDefinition, ExtensionInstallation, AICapabilityPolicy)
+        .join(
+            ExtensionInstallation,
+            CapabilityDefinition.installation_id == ExtensionInstallation.id,
+        )
+        .outerjoin(
+            AICapabilityPolicy,
+            AICapabilityPolicy.capability_definition_id == CapabilityDefinition.id,
+        )
+        .order_by(
+            ExtensionInstallation.extension_id,
+            CapabilityDefinition.capability_id,
+            CapabilityDefinition.version,
+        )
+    )
+    return [_capability_policy_read(*row) for row in rows]
+
+
+@router.put(
+    "/capability-cost-policies/{capability_id}", response_model=CapabilityCostPolicyRead
+)
+def put_capability_cost_policy(
+    capability_id: UUID,
+    payload: CapabilityCostPolicyUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+):
+    _require_admin(current_user)
+    capability = db.get(CapabilityDefinition, capability_id)
+    if capability is None:
+        raise HTTPException(status_code=404, detail="Capability definition not found")
+    installation = db.get(ExtensionInstallation, capability.installation_id)
+    row = db.get(AICapabilityPolicy, capability_id)
+    if row is None:
+        row = AICapabilityPolicy(capability_definition_id=capability_id)
+        db.add(row)
+    row.classification = AICapabilityClassification(payload.classification)
+    row.cost_units = payload.cost_units
+    row.updated_by_user_id = current_user.id
+    db.commit()
+    db.refresh(row)
+    return _capability_policy_read(capability, installation, row)
+
+
+def _entitlement_read(db: Session, user: User) -> AIEntitlementRead:
+    payload = entitlement_payload(db, user.id)
+    return AIEntitlementRead(
+        user_id=user.id, user_name=user.name, user_email=user.email, **payload
+    )
+
+
+@router.get("/ai-entitlements", response_model=list[AIEntitlementRead])
+def list_ai_entitlements(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+):
+    _require_admin(current_user)
+    users = db.scalars(select(User).order_by(User.name, User.normalized_email))
+    return [_entitlement_read(db, user) for user in users]
+
+
+@router.put("/users/{user_id}/ai-entitlement", response_model=AIEntitlementRead)
+def put_ai_entitlement(
+    user_id: UUID,
+    payload: AIEntitlementUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+):
+    _require_admin(current_user)
+    user = db.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    period = utc_month_start()
+    row = db.get(AIEntitlement, user_id)
+    if row is None:
+        row = AIEntitlement(user_id=user_id, used_units=0, period_start=period)
+        db.add(row)
+    elif row.period_start != period:
+        row.period_start = period
+        row.used_units = 0
+    row.state = AIEntitlementState(payload.state)
+    row.monthly_limit_units = payload.monthly_limit_units
+    row.updated_by_user_id = current_user.id
+    db.commit()
+    db.refresh(row)
+    return _entitlement_read(db, user)
+
+
+@router.get("/ai-usage", response_model=AIUsageRead)
+def read_ai_usage(
+    user_id: UUID | None = None,
+    limit: int = Query(default=100, ge=1, le=500),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+):
+    _require_admin(current_user)
+    period = utc_month_start()
+    statement = (
+        select(AIUsageCharge, User, CapabilityDefinition)
+        .join(User, AIUsageCharge.user_id == User.id)
+        .join(
+            CapabilityDefinition,
+            AIUsageCharge.capability_definition_id == CapabilityDefinition.id,
+        )
+        .where(AIUsageCharge.period_start == period)
+        .order_by(AIUsageCharge.created_at.desc())
+        .limit(limit)
+    )
+    if user_id is not None:
+        statement = statement.where(AIUsageCharge.user_id == user_id)
+    rows = db.execute(statement)
+    charges = [
+        AIUsageChargeRead(
+            id=charge.id,
+            execution_id=charge.execution_id,
+            user_id=charge.user_id,
+            user_email=user.email,
+            capability_definition_id=charge.capability_definition_id,
+            capability_id=capability.capability_id,
+            units=charge.units,
+            period_start=charge.period_start,
+            created_at=charge.created_at,
+        )
+        for charge, user, capability in rows
+    ]
+    total = usage_total_for_period(db, period)
+    if user_id is not None:
+        total = int(
+            db.scalar(
+                select(func.coalesce(func.sum(AIUsageCharge.units), 0)).where(
+                    AIUsageCharge.period_start == period,
+                    AIUsageCharge.user_id == user_id,
+                )
+            )
+            or 0
+        )
+    return AIUsageRead(period_start=period, total_units=total, charges=charges)
+
+
+@self_router.get("/entitlement", response_model=SelfAIEntitlementRead)
+def read_my_ai_entitlement(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(session_dependency),
+):
+    return SelfAIEntitlementRead(**entitlement_payload(db, current_user.id))
+
+
+__all__ = ["router", "self_router"]

--- a/src/fair_platform/backend/api/routers/auth.py
+++ b/src/fair_platform/backend/api/routers/auth.py
@@ -2,17 +2,19 @@ import os
 from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
-from fair_platform.backend.api.schema.user import AuthUserRead, UserCreate
+from fair_platform.backend.api.schema.user import AuthUserRead, RegistrationRequest
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jose import jwt, JWTError
 import bcrypt
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 
 from fair_platform.backend.data.database import session_dependency
 from fair_platform.backend.data.models import User
 from fair_platform.backend.data.models.user import UserRole
+from fair_platform.backend.data.models.user import normalize_email_address
 from fair_platform.backend.core.config import (
     INSECURE_DEFAULT_SECRET_KEY,
     get_base_url,
@@ -23,6 +25,7 @@ from fair_platform.backend.core.config import (
 from fair_platform.backend.core.security.permissions import auth_user_payload
 from fair_platform.backend.api.schema.casing import to_camel_keys
 from fair_platform.backend.services.mailer import Mailer, get_mailer
+from fair_platform.backend.services.access_control import authorize_registration
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -245,28 +248,47 @@ def get_current_user(
 
 @router.post("/register", status_code=status.HTTP_201_CREATED)
 async def register(
-    user_in: UserCreate,
+    user_in: RegistrationRequest,
     response: Response,
     db: Session = Depends(session_dependency),
     mailer: Mailer = Depends(get_mailer),
 ):
     """Register a new user with password hashing"""
-    existing = db.query(User).filter(User.email == user_in.email).first()
+    normalized_email = normalize_email_address(str(user_in.email))
+    existing = db.query(User).filter(User.normalized_email == normalized_email).first()
     if existing:
         raise HTTPException(status_code=400, detail="Email already registered")
 
+    invitation = authorize_registration(
+        db,
+        normalized_email=normalized_email,
+        invite_token=user_in.invite_token,
+    )
     password_hash = hash_password(user_in.password)
 
     user = User(
         id=uuid4(),
         name=user_in.name,
         email=user_in.email,
+        normalized_email=normalized_email,
         role=UserRole.user.value,
         password_hash=password_hash,
         is_verified=not get_email_enabled(),
     )
     db.add(user)
-    db.commit()
+    try:
+        # Insert the user before updating the invitation's foreign key. This
+        # keeps SQLite and PostgreSQL ordering identical without weakening the
+        # single registration transaction.
+        db.flush()
+        if invitation is not None:
+            invitation.redeemed_at = datetime.now(timezone.utc)
+            invitation.redeemed_by_user_id = user.id
+            db.add(invitation)
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Email already registered") from exc
     db.refresh(user)
 
     if get_email_enabled() and not user.is_verified:
@@ -305,7 +327,11 @@ def login(
     db: Session = Depends(session_dependency),
 ):
     """Login endpoint with proper password verification"""
-    user = db.query(User).filter(User.email == form_data.username).first()
+    try:
+        normalized_email = normalize_email_address(form_data.username)
+    except ValueError:
+        normalized_email = ""
+    user = db.query(User).filter(User.normalized_email == normalized_email).first()
     if not user:
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
@@ -357,7 +383,8 @@ async def forgot_password(
             detail=EMAIL_DISABLED_MESSAGE,
         )
 
-    user = db.query(User).filter(User.email == payload.email).first()
+    normalized_email = normalize_email_address(str(payload.email))
+    user = db.query(User).filter(User.normalized_email == normalized_email).first()
     if user:
         reset_token = _create_action_token(
             user=user,
@@ -412,7 +439,8 @@ async def resend_verification_request(
             detail=EMAIL_DISABLED_MESSAGE,
         )
 
-    user = db.query(User).filter(User.email == payload.email).first()
+    normalized_email = normalize_email_address(str(payload.email))
+    user = db.query(User).filter(User.normalized_email == normalized_email).first()
     if user and not user.is_verified:
         verification_token = _create_action_token(
             user=user,

--- a/src/fair_platform/backend/api/routers/executions.py
+++ b/src/fair_platform/backend/api/routers/executions.py
@@ -86,6 +86,7 @@ from fair_platform.backend.services.execution_store import (
     create_execution,
     normalize_standard_event_payload,
 )
+from fair_platform.backend.services.access_control import AccessPolicyError
 from fair_platform.backend.services.flow_runtime import (
     FlowRuntimeError,
     advance_flow_execution,
@@ -627,7 +628,9 @@ def _resolve_function_scope(
 ) -> tuple[UUID | None, UUID | None]:
     """Authorize the course/assignment a function run claims to act in."""
 
-    assignment = db.get(Assignment, payload.assignment_id) if payload.assignment_id else None
+    assignment = (
+        db.get(Assignment, payload.assignment_id) if payload.assignment_id else None
+    )
     if payload.assignment_id is not None and assignment is None:
         raise HTTPException(status_code=404, detail="Assignment not found")
     course_id = assignment.course_id if assignment else payload.course_id
@@ -967,7 +970,19 @@ def ingest_extension_events(
             execution.status
         ) in {"completed", "failed", "cancelled", "expired"}:
             try:
-                advance_flow_execution(db, execution.root_execution_id)
+                # Later Flow steps are created after an extension event has already
+                # been projected. Isolate the next-step reservation so a quota
+                # denial removes the undispatched step without discarding the
+                # accepted terminal event for the previous step.
+                with db.begin_nested():
+                    advance_flow_execution(db, execution.root_execution_id)
+            except AccessPolicyError as exc:
+                fail_flow_execution(
+                    db,
+                    execution.root_execution_id,
+                    exc.detail,
+                    error_code=exc.code,
+                )
             except FlowRuntimeError as exc:
                 fail_flow_execution(db, execution.root_execution_id, str(exc))
         db.commit()

--- a/src/fair_platform/backend/api/routers/extensions.py
+++ b/src/fair_platform/backend/api/routers/extensions.py
@@ -51,6 +51,7 @@ from fair_platform.backend.services.execution_protocol import (
     build_execution_command,
 )
 from fair_platform.backend.services.execution_lifecycle import expire_due_executions
+from fair_platform.backend.services.access_control import capability_cost_control
 from fair_platform.extension_sdk.contracts.extension import (
     CapabilityManifest,
     ExtensionManifest,
@@ -103,13 +104,28 @@ def _schema_uri(schema: dict, fallback: str) -> str:
     return str(schema.get("$id") or fallback)
 
 
-def _capability_read(row: CapabilityDefinition) -> CapabilityRead:
+def _capability_read(
+    row: CapabilityDefinition,
+    *,
+    db: Session | None = None,
+    user: User | None = None,
+) -> CapabilityRead:
     snapshot = CapabilityManifest.model_validate(row.manifest_snapshot or {})
+    cost_control = (
+        capability_cost_control(
+            db,
+            capability_definition_id=row.id,
+            user_id=user.id if user is not None else None,
+        )
+        if db is not None
+        else None
+    )
     return CapabilityRead(
         **snapshot.model_dump(),
         id=row.id,
         installation_id=row.installation_id,
         created_at=row.created_at,
+        cost_control=cost_control,
     )
 
 
@@ -279,7 +295,9 @@ def sync_own_manifest(
     installation.display_name = manifest.display_name
     installation.version = manifest.version
     installation.manifest_version = manifest.manifest_version
-    installation.manifest = manifest.model_dump(by_alias=True, mode="json", exclude_none=True)
+    installation.manifest = manifest.model_dump(
+        by_alias=True, mode="json", exclude_none=True
+    )
     _sync_capabilities(db, installation, manifest)
     db.commit()
 
@@ -497,7 +515,9 @@ def list_capabilities(
         statement = statement.where(
             CapabilityDefinition.installation_id == installation_id
         )
-    return [_capability_read(row) for row in db.scalars(statement)]
+    return [
+        _capability_read(row, db=db, user=current_user) for row in db.scalars(statement)
+    ]
 
 
 @router.get("/capabilities/{capability_id}", response_model=CapabilityRead)
@@ -517,7 +537,7 @@ def get_capability(
     )
     if row is None:
         raise HTTPException(status_code=404, detail="Capability not found")
-    return _capability_read(row)
+    return _capability_read(row, db=db, user=current_user)
 
 
 @router.post("/grants", response_model=GrantRead, status_code=status.HTTP_201_CREATED)

--- a/src/fair_platform/backend/api/routers/system.py
+++ b/src/fair_platform/backend/api/routers/system.py
@@ -1,14 +1,27 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
 
 from fair_platform.backend.core.config import get_email_enabled
+from fair_platform.backend.data.database import session_dependency
+from fair_platform.backend.services.access_control import resolve_platform_policy
 from fair_platform.backend.services.dispatch_signing import get_dispatch_signer
 
 router = APIRouter()
 
 
 @router.get("/config")
-def get_system_config():
-    return {"features": {"email_enabled": get_email_enabled()}}
+def get_system_config(db: Session = Depends(session_dependency)):
+    policy = resolve_platform_policy(db)
+    return {
+        "features": {
+            "email_enabled": get_email_enabled(),
+            "ai_controls_enabled": policy.ai_controls_enabled,
+        },
+        "registration": {
+            "mode": policy.admission_mode.value,
+            "invite_required": policy.admission_mode.value == "invite_only",
+        },
+    }
 
 
 @router.get("/signing-keys")

--- a/src/fair_platform/backend/api/routers/users.py
+++ b/src/fair_platform/backend/api/routers/users.py
@@ -1,7 +1,8 @@
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 
 from fair_platform.backend.api.routers.auth import get_current_user
 from fair_platform.backend.data.models.user import User
@@ -112,7 +113,11 @@ def update_user(
             else getattr(payload.role, "value", payload.role)
         )
     db.add(user)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Email already registered") from exc
     db.refresh(user)
     return user
 

--- a/src/fair_platform/backend/api/schema/access_control.py
+++ b/src/fair_platform/backend/api/schema/access_control.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr, Field, model_validator
+
+from fair_platform.backend.api.schema.utils import schema_config
+
+
+AdmissionModeValue = Literal["open", "allowlist", "invite_only"]
+
+
+class PlatformPolicyRead(BaseModel):
+    model_config = schema_config
+    stored_admission_mode: AdmissionModeValue
+    effective_admission_mode: AdmissionModeValue
+    admission_source: Literal["database", "environment"]
+    admission_locked: bool
+    stored_ai_controls_enabled: bool
+    effective_ai_controls_enabled: bool
+    ai_controls_source: Literal["database", "environment"]
+    ai_controls_locked: bool
+    updated_at: datetime | None
+
+
+class PlatformPolicyUpdate(BaseModel):
+    model_config = schema_config
+    admission_mode: AdmissionModeValue | None = None
+    ai_controls_enabled: bool | None = None
+
+
+class AdmissionRuleCreate(BaseModel):
+    model_config = schema_config
+    kind: Literal["email", "domain"]
+    value: str = Field(min_length=1, max_length=320)
+
+
+class AdmissionRuleRead(BaseModel):
+    model_config = schema_config
+    id: UUID
+    kind: Literal["email", "domain"]
+    value: str
+    created_at: datetime
+
+
+class InviteCreate(BaseModel):
+    model_config = schema_config
+    email: EmailStr
+    expires_in_days: int = Field(default=7, ge=1, le=90)
+
+
+class InviteRead(BaseModel):
+    model_config = schema_config
+    id: UUID
+    email: EmailStr
+    expires_at: datetime
+    redeemed_at: datetime | None
+    revoked_at: datetime | None
+    created_at: datetime
+    active: bool
+
+
+class InviteSecretRead(InviteRead):
+    token: str
+    registration_url: str
+
+
+class CapabilityCostPolicyUpdate(BaseModel):
+    model_config = schema_config
+    classification: Literal["unmetered", "ai"]
+    cost_units: int = Field(ge=0, le=1_000_000)
+
+    @model_validator(mode="after")
+    def validate_weight(self):
+        if self.classification == "unmetered" and self.cost_units != 0:
+            raise ValueError("Unmetered capabilities must cost 0 units")
+        if self.classification == "ai" and self.cost_units <= 0:
+            raise ValueError("AI capabilities must cost at least 1 unit")
+        return self
+
+
+class CapabilityCostPolicyRead(BaseModel):
+    model_config = schema_config
+    capability_definition_id: UUID
+    capability_id: str
+    display_name: str | None
+    version: str
+    surface: str
+    extension_id: str
+    classification: Literal["unclassified", "unmetered", "ai"]
+    cost_units: int | None
+    updated_at: datetime | None
+
+
+class AIEntitlementUpdate(BaseModel):
+    model_config = schema_config
+    state: Literal["disabled", "limited", "unlimited"]
+    monthly_limit_units: int | None = Field(default=None, ge=1, le=1_000_000_000)
+
+    @model_validator(mode="after")
+    def validate_limit(self):
+        if self.state == "limited" and self.monthly_limit_units is None:
+            raise ValueError("Limited entitlements require a monthly limit")
+        if self.state != "limited" and self.monthly_limit_units is not None:
+            raise ValueError("Only limited entitlements have a monthly limit")
+        return self
+
+
+class AIEntitlementRead(BaseModel):
+    model_config = schema_config
+    user_id: UUID
+    user_name: str
+    user_email: EmailStr
+    state: Literal["disabled", "limited", "unlimited"]
+    monthly_limit_units: int | None
+    used_units: int
+    remaining_units: int | None
+    period_start: date
+    next_reset_at: datetime
+    controls_enabled: bool
+
+
+class SelfAIEntitlementRead(BaseModel):
+    model_config = schema_config
+    state: Literal["disabled", "limited", "unlimited"]
+    monthly_limit_units: int | None
+    used_units: int
+    remaining_units: int | None
+    period_start: date
+    next_reset_at: datetime
+    controls_enabled: bool
+
+
+class AIUsageChargeRead(BaseModel):
+    model_config = schema_config
+    id: UUID
+    execution_id: UUID
+    user_id: UUID
+    user_email: EmailStr
+    capability_definition_id: UUID
+    capability_id: str
+    units: int
+    period_start: date
+    created_at: datetime
+
+
+class AIUsageRead(BaseModel):
+    model_config = schema_config
+    period_start: date
+    total_units: int
+    charges: list[AIUsageChargeRead]
+
+
+__all__ = [name for name in globals() if not name.startswith("_")]

--- a/src/fair_platform/backend/api/schema/extension.py
+++ b/src/fair_platform/backend/api/schema/extension.py
@@ -28,6 +28,19 @@ class CapabilityRead(CapabilityManifest):
     id: UUID
     installation_id: UUID
     created_at: datetime
+    cost_control: "CapabilityCostControlRead | None" = None
+
+
+class CapabilityCostControlRead(BaseModel):
+    model_config = schema_config
+    controls_enabled: bool
+    classification: Literal["unclassified", "unmetered", "ai"]
+    cost_units: int | None
+    executable: bool
+    reason: (
+        Literal["ai_policy_unconfigured", "ai_not_entitled", "ai_quota_exhausted"]
+        | None
+    )
 
 
 class InstallationRead(BaseModel):

--- a/src/fair_platform/backend/api/schema/user.py
+++ b/src/fair_platform/backend/api/schema/user.py
@@ -4,12 +4,15 @@ from uuid import UUID
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from fair_platform.backend.data.models.user import UserRole
-from fair_platform.backend.api.schema.utils import schema_config, schema_config_with_enum
+from fair_platform.backend.api.schema.utils import (
+    schema_config,
+    schema_config_with_enum,
+)
 
 
 class UserBase(BaseModel):
     model_config = schema_config_with_enum
-    
+
     name: str
     email: EmailStr
     role: UserRole = UserRole.user
@@ -29,9 +32,18 @@ class UserCreate(UserBase):
     password: str
 
 
+class RegistrationRequest(BaseModel):
+    model_config = schema_config
+
+    name: str = Field(min_length=1, max_length=255)
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=128)
+    invite_token: str | None = Field(default=None, max_length=512)
+
+
 class UserUpdate(BaseModel):
     model_config = schema_config_with_enum
-    
+
     name: Optional[str] = None
     email: Optional[EmailStr] = None
     role: Optional[UserRole] = None
@@ -62,6 +74,7 @@ __all__ = [
     "UserRole",
     "UserBase",
     "UserCreate",
+    "RegistrationRequest",
     "UserUpdate",
     "UserRead",
     "AuthUserRead",

--- a/src/fair_platform/backend/core/config.py
+++ b/src/fair_platform/backend/core/config.py
@@ -3,6 +3,7 @@ from typing import Literal
 from urllib.parse import urlparse
 
 DeploymentMode = Literal["COMMUNITY", "ENTERPRISE"]
+AdmissionModeValue = Literal["open", "allowlist", "invite_only"]
 INSECURE_DEFAULT_SECRET_KEY = "fair-insecure-default-key"
 
 
@@ -15,6 +16,34 @@ def _parse_bool_env(raw: str | None, *, default: bool = False) -> bool:
     if normalized in {"0", "false", "no", "off"}:
         return False
     return default
+
+
+def _parse_strict_bool_env(name: str) -> bool | None:
+    raw = os.getenv(name)
+    if raw is None:
+        return None
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise RuntimeError(f"{name} must be a boolean value")
+
+
+def get_admission_mode_override() -> AdmissionModeValue | None:
+    raw = os.getenv("FAIR_ADMISSION_MODE")
+    if raw is None:
+        return None
+    normalized = raw.strip().lower().replace("-", "_")
+    if normalized not in {"open", "allowlist", "invite_only"}:
+        raise RuntimeError(
+            "FAIR_ADMISSION_MODE must be one of: open, allowlist, invite_only"
+        )
+    return normalized  # type: ignore[return-value]
+
+
+def get_ai_controls_enabled_override() -> bool | None:
+    return _parse_strict_bool_env("FAIR_AI_CONTROLS_ENABLED")
 
 
 def get_deployment_mode() -> DeploymentMode:
@@ -33,6 +62,8 @@ def get_secret_key() -> str:
 
 def validate_security_configuration(secret_key: str | None = None) -> None:
     """Reject development-only authentication defaults in institutional mode."""
+    get_admission_mode_override()
+    get_ai_controls_enabled_override()
     resolved_secret = secret_key or get_secret_key()
     if get_deployment_mode() != "ENTERPRISE":
         return

--- a/src/fair_platform/backend/data/models/__init__.py
+++ b/src/fair_platform/backend/data/models/__init__.py
@@ -1,4 +1,16 @@
 from .user import User, UserRole
+from .access_control import (
+    AdmissionMode,
+    AdmissionRule,
+    AdmissionRuleKind,
+    AICapabilityClassification,
+    AICapabilityPolicy,
+    AIEntitlement,
+    AIEntitlementState,
+    AIUsageCharge,
+    PlatformPolicy,
+    RegistrationInvite,
+)
 from .course import Course
 from .assignment import Assignment, AssignmentStatus
 from .enrollment import Enrollment, CourseMembershipRole, EnrollmentStatus
@@ -120,6 +132,16 @@ from .lms_quiz import (
 __all__ = [
     "User",
     "UserRole",
+    "AdmissionMode",
+    "AdmissionRule",
+    "AdmissionRuleKind",
+    "AICapabilityClassification",
+    "AICapabilityPolicy",
+    "AIEntitlement",
+    "AIEntitlementState",
+    "AIUsageCharge",
+    "PlatformPolicy",
+    "RegistrationInvite",
     "Course",
     "Assignment",
     "AssignmentStatus",

--- a/src/fair_platform/backend/data/models/access_control.py
+++ b/src/fair_platform/backend/data/models/access_control.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from enum import Enum
+from typing import Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    Date,
+    DateTime,
+    false,
+    ForeignKey,
+    func,
+    Index,
+    Integer,
+    SmallInteger,
+    String,
+    UUID as SAUUID,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..database import Base
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class AdmissionMode(str, Enum):
+    open = "open"
+    allowlist = "allowlist"
+    invite_only = "invite_only"
+
+
+class AdmissionRuleKind(str, Enum):
+    email = "email"
+    domain = "domain"
+
+
+class AICapabilityClassification(str, Enum):
+    unmetered = "unmetered"
+    ai = "ai"
+
+
+class AIEntitlementState(str, Enum):
+    disabled = "disabled"
+    limited = "limited"
+    unlimited = "unlimited"
+
+
+class PlatformPolicy(Base):
+    __tablename__ = "platform_policies"
+    __table_args__ = (
+        CheckConstraint("id = 1", name="ck_platform_policy_singleton"),
+        CheckConstraint(
+            "admission_mode IN ('open', 'allowlist', 'invite_only')",
+            name="ck_platform_policy_admission_mode",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(SmallInteger, primary_key=True, default=1)
+    admission_mode: Mapped[AdmissionMode] = mapped_column(
+        String(32),
+        nullable=False,
+        default=AdmissionMode.open,
+        server_default=AdmissionMode.open.value,
+    )
+    ai_controls_enabled: Mapped[bool] = mapped_column(
+        nullable=False, default=False, server_default=false()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utc_now,
+        server_default=func.now(),
+        onupdate=utc_now,
+    )
+    updated_by_user_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+
+
+class AdmissionRule(Base):
+    __tablename__ = "admission_rules"
+    __table_args__ = (
+        UniqueConstraint("kind", "normalized_value", name="uq_admission_rule_value"),
+        CheckConstraint("kind IN ('email', 'domain')", name="ck_admission_rule_kind"),
+        Index("ix_admission_rules_kind_value", "kind", "normalized_value"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    kind: Mapped[AdmissionRuleKind] = mapped_column(String(16), nullable=False)
+    normalized_value: Mapped[str] = mapped_column(String(320), nullable=False)
+    created_by_user_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utc_now,
+        server_default=func.now(),
+    )
+
+
+class RegistrationInvite(Base):
+    __tablename__ = "registration_invites"
+    __table_args__ = (
+        UniqueConstraint("token_hash", name="uq_registration_invites_token_hash"),
+        Index("ix_registration_invites_email", "normalized_email", "expires_at"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    token_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    normalized_email: Mapped[str] = mapped_column(String(320), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    redeemed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    redeemed_by_user_id: Mapped[Optional[UUID]] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    revoked_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_by_user_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utc_now,
+        server_default=func.now(),
+    )
+
+
+class AICapabilityPolicy(Base):
+    __tablename__ = "ai_capability_policies"
+    __table_args__ = (
+        CheckConstraint("cost_units >= 0", name="ck_ai_capability_cost_nonnegative"),
+        CheckConstraint(
+            "(classification = 'unmetered' AND cost_units = 0) OR "
+            "(classification = 'ai' AND cost_units > 0)",
+            name="ck_ai_capability_classification_cost",
+        ),
+        CheckConstraint(
+            "classification IN ('unmetered', 'ai')",
+            name="ck_ai_capability_classification",
+        ),
+    )
+
+    capability_definition_id: Mapped[UUID] = mapped_column(
+        SAUUID,
+        ForeignKey("capability_definitions.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    classification: Mapped[AICapabilityClassification] = mapped_column(
+        String(16), nullable=False
+    )
+    cost_units: Mapped[int] = mapped_column(Integer, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utc_now,
+        server_default=func.now(),
+        onupdate=utc_now,
+    )
+    updated_by_user_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+    )
+
+    capability = relationship("CapabilityDefinition")
+
+
+class AIEntitlement(Base):
+    __tablename__ = "ai_entitlements"
+    __table_args__ = (
+        CheckConstraint("used_units >= 0", name="ck_ai_entitlement_used_nonnegative"),
+        CheckConstraint(
+            "monthly_limit_units IS NULL OR monthly_limit_units > 0",
+            name="ck_ai_entitlement_limit_positive",
+        ),
+        CheckConstraint(
+            "(state = 'limited' AND monthly_limit_units IS NOT NULL) OR "
+            "(state != 'limited' AND monthly_limit_units IS NULL)",
+            name="ck_ai_entitlement_state_limit",
+        ),
+        CheckConstraint(
+            "state IN ('disabled', 'limited', 'unlimited')",
+            name="ck_ai_entitlement_state",
+        ),
+    )
+
+    user_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    state: Mapped[AIEntitlementState] = mapped_column(
+        String(16),
+        nullable=False,
+        default=AIEntitlementState.disabled,
+        server_default=AIEntitlementState.disabled.value,
+    )
+    monthly_limit_units: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    used_units: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    period_start: Mapped[date] = mapped_column(Date, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utc_now,
+        server_default=func.now(),
+        onupdate=utc_now,
+    )
+    updated_by_user_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+    )
+
+    user = relationship("User", foreign_keys=[user_id])
+
+
+class AIUsageCharge(Base):
+    __tablename__ = "ai_usage_charges"
+    __table_args__ = (
+        CheckConstraint("units > 0", name="ck_ai_usage_charge_units_positive"),
+        UniqueConstraint("execution_id", name="uq_ai_usage_charges_execution_id"),
+        Index("ix_ai_usage_user_period", "user_id", "period_start", "created_at"),
+    )
+
+    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    execution_id: Mapped[UUID] = mapped_column(
+        SAUUID,
+        ForeignKey("executions.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        SAUUID, ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+    )
+    capability_definition_id: Mapped[UUID] = mapped_column(
+        SAUUID,
+        ForeignKey("capability_definitions.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    units: Mapped[int] = mapped_column(Integer, nullable=False)
+    period_start: Mapped[date] = mapped_column(Date, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=utc_now,
+        server_default=func.now(),
+    )
+
+    execution = relationship("Execution")
+    user = relationship("User")
+    capability = relationship("CapabilityDefinition")
+
+
+__all__ = [
+    "AdmissionMode",
+    "AdmissionRule",
+    "AdmissionRuleKind",
+    "AICapabilityClassification",
+    "AICapabilityPolicy",
+    "AIEntitlement",
+    "AIEntitlementState",
+    "AIUsageCharge",
+    "PlatformPolicy",
+    "RegistrationInvite",
+]

--- a/src/fair_platform/backend/data/models/user.py
+++ b/src/fair_platform/backend/data/models/user.py
@@ -4,7 +4,7 @@ from typing import Optional
 from typing import Any
 
 from pydantic import EmailStr
-from sqlalchemy import Boolean, String, UUID as SAUUID
+from sqlalchemy import Boolean, String, UniqueConstraint, UUID as SAUUID, event
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import List, TYPE_CHECKING
 
@@ -31,10 +31,14 @@ class UserRole(str, Enum):
 
 class User(Base):
     __tablename__ = "users"
+    __table_args__ = (
+        UniqueConstraint("normalized_email", name="uq_users_normalized_email"),
+    )
 
     id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True)
     name: Mapped[str] = mapped_column(String, nullable=False)
     email: Mapped[EmailStr] = mapped_column(String, nullable=False)
+    normalized_email: Mapped[str] = mapped_column(String(320), nullable=False)
     role: Mapped[str] = mapped_column(String, nullable=False)
     password_hash: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     is_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
@@ -57,7 +61,9 @@ class User(Base):
     )
     # Relationship to submissions created by this user (professor/admin)
     created_submissions: Mapped[List["Submission"]] = relationship(
-        "Submission", back_populates="created_by", foreign_keys="Submission.created_by_id"
+        "Submission",
+        back_populates="created_by",
+        foreign_keys="Submission.created_by_id",
     )
     rubrics: Mapped[List["Rubric"]] = relationship("Rubric", back_populates="creator")
     enrollments: Mapped[List["Enrollment"]] = relationship(
@@ -66,3 +72,23 @@ class User(Base):
 
     def __repr__(self) -> str:
         return f"<User id={self.id} email={self.email!r} role={self.role}>"
+
+
+def normalize_email_address(value: str) -> str:
+    """Return FAIR's canonical identity key for an email address."""
+
+    address = value.strip()
+    local, separator, domain = address.rpartition("@")
+    if not separator or not local or not domain:
+        raise ValueError("A valid email address is required")
+    try:
+        normalized_domain = domain.encode("idna").decode("ascii").casefold()
+    except UnicodeError as exc:
+        raise ValueError("A valid email address is required") from exc
+    return f"{local.casefold()}@{normalized_domain}"
+
+
+@event.listens_for(User, "before_insert")
+@event.listens_for(User, "before_update")
+def _synchronize_normalized_email(_mapper, _connection, target: User) -> None:
+    target.normalized_email = normalize_email_address(str(target.email))

--- a/src/fair_platform/backend/main.py
+++ b/src/fair_platform/backend/main.py
@@ -1,10 +1,10 @@
 import importlib.resources
 import os
 import logging
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from contextlib import asynccontextmanager
 
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.cors import CORSMiddleware
 
@@ -20,7 +20,9 @@ from fair_platform.backend.api.routers.auth import router as auth_router
 from fair_platform.backend.api.routers.version import router as version_router
 from fair_platform.backend.api.routers.rubrics import router as rubrics_router
 from fair_platform.backend.api.routers.enrollments import router as enrollments_router
-from fair_platform.backend.api.routers.extensions import router as extension_resources_router
+from fair_platform.backend.api.routers.extensions import (
+    router as extension_resources_router,
+)
 from fair_platform.backend.api.routers.system import router as system_router
 from fair_platform.backend.api.routers.executions import router as executions_router
 from fair_platform.backend.api.routers.artifacts import router as artifacts_router
@@ -35,12 +37,18 @@ from fair_platform.backend.api.routers.student_dashboard import (
 )
 from fair_platform.backend.api.routers.quizzes import router as quizzes_router
 from fair_platform.backend.api.routers.course_copy import router as course_copy_router
+from fair_platform.backend.api.routers.admin_access import (
+    router as admin_access_router,
+    self_router as ai_access_router,
+)
+from fair_platform.backend.services.access_control import AccessPolicyError
 from fair_platform.backend.services.execution_outbox_dispatcher import (
     ExecutionOutboxDispatcher,
 )
 from fair_platform.backend.data.database import SessionLocal
 
 logger = logging.getLogger(__name__)
+
 
 def _is_auto_migrate_enabled() -> bool:
     raw = os.getenv("FAIR_AUTO_MIGRATE", "1").strip().lower()
@@ -68,10 +76,14 @@ def _configured_cors_origins() -> list[str]:
 def _is_execution_dispatcher_enabled() -> bool:
     if os.getenv("PYTEST_CURRENT_TEST"):
         return False
-    raw = os.getenv(
-        "FAIR_ENABLE_EXECUTION_DISPATCHER",
-        "1",
-    ).strip().lower()
+    raw = (
+        os.getenv(
+            "FAIR_ENABLE_EXECUTION_DISPATCHER",
+            "1",
+        )
+        .strip()
+        .lower()
+    )
     return raw in {"1", "true", "yes", "on"}
 
 
@@ -119,6 +131,15 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+@app.exception_handler(AccessPolicyError)
+async def access_policy_error_handler(_request: Request, exc: AccessPolicyError):
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"detail": exc.detail, "code": exc.code, **exc.extra},
+    )
+
+
 app.include_router(users_router, prefix="/api/users", tags=["users"])
 app.include_router(courses_router, prefix="/api/courses", tags=["courses"])
 app.include_router(assignments_router, prefix="/api/assignments", tags=["assignments"])
@@ -128,15 +149,15 @@ app.include_router(version_router, prefix="/api", tags=["version"])
 app.include_router(rubrics_router, prefix="/api/rubrics", tags=["rubrics"])
 app.include_router(enrollments_router, prefix="/api/enrollments", tags=["enrollments"])
 app.include_router(lms_router, prefix="/api/lms", tags=["lms"])
-app.include_router(
-    course_content_router, prefix="/api/lms", tags=["course-content"]
-)
+app.include_router(course_content_router, prefix="/api/lms", tags=["course-content"])
 app.include_router(gradebook_router, prefix="/api/lms", tags=["gradebook"])
 app.include_router(
     student_dashboard_router, prefix="/api/lms", tags=["student-dashboard"]
 )
 app.include_router(quizzes_router, prefix="/api/lms", tags=["quizzes"])
 app.include_router(course_copy_router, prefix="/api/lms", tags=["course-copy"])
+app.include_router(admin_access_router, prefix="/api/v1/admin", tags=["admin"])
+app.include_router(ai_access_router, prefix="/api/v1/ai", tags=["ai-access"])
 app.include_router(system_router, prefix="/api/v1/system", tags=["system"])
 app.include_router(executions_router, prefix="/api/v1", tags=["executions"])
 app.include_router(artifacts_router, prefix="/api/v1", tags=["artifacts"])

--- a/src/fair_platform/backend/services/access_control.py
+++ b/src/fair_platform/backend/services/access_control.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func, or_, select, update
+from sqlalchemy.orm import Session
+
+from fair_platform.backend.core.config import (
+    get_admission_mode_override,
+    get_ai_controls_enabled_override,
+)
+from fair_platform.backend.data.models.access_control import (
+    AdmissionMode,
+    AdmissionRule,
+    AdmissionRuleKind,
+    AICapabilityClassification,
+    AICapabilityPolicy,
+    AIEntitlement,
+    AIEntitlementState,
+    AIUsageCharge,
+    PlatformPolicy,
+    RegistrationInvite,
+)
+from fair_platform.backend.data.models.user import normalize_email_address
+
+
+class AccessPolicyError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        code: str,
+        detail: str,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+        self.code = code
+        self.detail = detail
+        self.extra = extra or {}
+
+
+@dataclass(frozen=True)
+class EffectivePlatformPolicy:
+    admission_mode: AdmissionMode
+    admission_source: str
+    ai_controls_enabled: bool
+    ai_controls_source: str
+
+
+def _value(value: object) -> str:
+    return value.value if hasattr(value, "value") else str(value)
+
+
+def _as_utc(value: datetime) -> datetime:
+    return (
+        value.replace(tzinfo=timezone.utc)
+        if value.tzinfo is None
+        else value.astimezone(timezone.utc)
+    )
+
+
+def utc_month_start(now: datetime | None = None) -> date:
+    resolved = now or datetime.now(timezone.utc)
+    return date(resolved.year, resolved.month, 1)
+
+
+def next_utc_month_start(period_start: date) -> datetime:
+    if period_start.month == 12:
+        return datetime(period_start.year + 1, 1, 1, tzinfo=timezone.utc)
+    return datetime(period_start.year, period_start.month + 1, 1, tzinfo=timezone.utc)
+
+
+def read_platform_policy(session: Session) -> PlatformPolicy | None:
+    return session.get(PlatformPolicy, 1)
+
+
+def get_or_create_platform_policy(session: Session) -> PlatformPolicy:
+    row = read_platform_policy(session)
+    if row is None:
+        row = PlatformPolicy(
+            id=1,
+            admission_mode=AdmissionMode.open,
+            ai_controls_enabled=False,
+        )
+        session.add(row)
+        session.flush()
+    return row
+
+
+def resolve_platform_policy(session: Session) -> EffectivePlatformPolicy:
+    stored = read_platform_policy(session)
+    stored_admission = (
+        AdmissionMode(_value(stored.admission_mode)) if stored else AdmissionMode.open
+    )
+    stored_ai = bool(stored.ai_controls_enabled) if stored else False
+    admission_override = get_admission_mode_override()
+    ai_override = get_ai_controls_enabled_override()
+    return EffectivePlatformPolicy(
+        admission_mode=(
+            AdmissionMode(admission_override)
+            if admission_override is not None
+            else stored_admission
+        ),
+        admission_source="environment"
+        if admission_override is not None
+        else "database",
+        ai_controls_enabled=ai_override if ai_override is not None else stored_ai,
+        ai_controls_source="environment" if ai_override is not None else "database",
+    )
+
+
+def normalize_domain(value: str) -> str:
+    domain = value.strip().lstrip("@").rstrip(".")
+    if not domain or "@" in domain:
+        raise ValueError("A valid domain is required")
+    try:
+        return domain.encode("idna").decode("ascii").casefold()
+    except UnicodeError as exc:
+        raise ValueError("A valid domain is required") from exc
+
+
+def normalize_admission_rule(kind: str, value: str) -> str:
+    if kind == AdmissionRuleKind.email.value:
+        return normalize_email_address(value)
+    if kind == AdmissionRuleKind.domain.value:
+        return normalize_domain(value)
+    raise ValueError("Admission rule kind must be email or domain")
+
+
+def _invite_hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def create_registration_invite(
+    session: Session,
+    *,
+    email: str,
+    created_by_user_id: UUID,
+    expires_in_days: int = 7,
+) -> tuple[RegistrationInvite, str]:
+    if not 1 <= expires_in_days <= 90:
+        raise ValueError("Invite expiry must be between 1 and 90 days")
+    token = secrets.token_urlsafe(32)
+    now = datetime.now(timezone.utc)
+    row = RegistrationInvite(
+        token_hash=_invite_hash(token),
+        normalized_email=normalize_email_address(email),
+        expires_at=now + timedelta(days=expires_in_days),
+        created_by_user_id=created_by_user_id,
+    )
+    session.add(row)
+    session.flush()
+    return row, token
+
+
+def authorize_registration(
+    session: Session,
+    *,
+    normalized_email: str,
+    invite_token: str | None,
+) -> RegistrationInvite | None:
+    mode = resolve_platform_policy(session).admission_mode
+    if mode is AdmissionMode.open:
+        return None
+    if mode is AdmissionMode.allowlist:
+        domain = normalized_email.rsplit("@", 1)[1]
+        allowed = session.scalar(
+            select(AdmissionRule.id).where(
+                or_(
+                    (
+                        (AdmissionRule.kind == AdmissionRuleKind.email)
+                        & (AdmissionRule.normalized_value == normalized_email)
+                    ),
+                    (
+                        (AdmissionRule.kind == AdmissionRuleKind.domain)
+                        & (AdmissionRule.normalized_value == domain)
+                    ),
+                )
+            )
+        )
+        if allowed is not None:
+            return None
+        raise AccessPolicyError(
+            status_code=403,
+            code="registration_not_permitted",
+            detail="Registration is not available for this email address.",
+        )
+
+    if not invite_token or len(invite_token) > 512:
+        raise AccessPolicyError(
+            status_code=403,
+            code="registration_not_permitted",
+            detail="A valid registration invitation is required.",
+        )
+    invitation = session.scalar(
+        select(RegistrationInvite)
+        .where(RegistrationInvite.token_hash == _invite_hash(invite_token))
+        .with_for_update()
+    )
+    now = datetime.now(timezone.utc)
+    if (
+        invitation is None
+        or invitation.normalized_email != normalized_email
+        or invitation.redeemed_at is not None
+        or invitation.revoked_at is not None
+        or _as_utc(invitation.expires_at) <= now
+    ):
+        raise AccessPolicyError(
+            status_code=403,
+            code="registration_not_permitted",
+            detail="A valid registration invitation is required.",
+        )
+    return invitation
+
+
+def _entitlement_payload(row: AIEntitlement | None) -> dict[str, Any]:
+    if row is None:
+        period = utc_month_start()
+        return {
+            "state": AIEntitlementState.disabled.value,
+            "monthlyLimitUnits": None,
+            "usedUnits": 0,
+            "remainingUnits": 0,
+            "periodStart": period,
+            "nextResetAt": next_utc_month_start(period),
+        }
+    period = row.period_start
+    used = row.used_units if period == utc_month_start() else 0
+    limit = row.monthly_limit_units
+    remaining = None if limit is None else max(limit - used, 0)
+    return {
+        "state": _value(row.state),
+        "monthlyLimitUnits": limit,
+        "usedUnits": used,
+        "remainingUnits": remaining,
+        "periodStart": utc_month_start() if period != utc_month_start() else period,
+        "nextResetAt": next_utc_month_start(
+            utc_month_start() if period != utc_month_start() else period
+        ),
+    }
+
+
+def entitlement_payload(session: Session, user_id: UUID) -> dict[str, Any]:
+    effective = resolve_platform_policy(session)
+    payload = _entitlement_payload(session.get(AIEntitlement, user_id))
+    payload["controlsEnabled"] = effective.ai_controls_enabled
+    return payload
+
+
+def capability_cost_control(
+    session: Session,
+    *,
+    capability_definition_id: UUID,
+    user_id: UUID | None,
+) -> dict[str, Any]:
+    effective = resolve_platform_policy(session)
+    policy = session.get(AICapabilityPolicy, capability_definition_id)
+    classification = _value(policy.classification) if policy else "unclassified"
+    units = policy.cost_units if policy else None
+    executable = True
+    reason = None
+    if effective.ai_controls_enabled:
+        if policy is None:
+            executable = False
+            reason = "ai_policy_unconfigured"
+        elif classification == AICapabilityClassification.ai.value:
+            if user_id is None:
+                executable = False
+                reason = "ai_not_entitled"
+            else:
+                entitlement = session.get(AIEntitlement, user_id)
+                state = _value(entitlement.state) if entitlement else "disabled"
+                if state == AIEntitlementState.disabled.value:
+                    executable = False
+                    reason = "ai_not_entitled"
+                elif state == AIEntitlementState.limited.value:
+                    used = (
+                        entitlement.used_units
+                        if entitlement.period_start == utc_month_start()
+                        else 0
+                    )
+                    if used + policy.cost_units > int(
+                        entitlement.monthly_limit_units or 0
+                    ):
+                        executable = False
+                        reason = "ai_quota_exhausted"
+    return {
+        "controlsEnabled": effective.ai_controls_enabled,
+        "classification": classification,
+        "costUnits": units,
+        "executable": executable,
+        "reason": reason,
+    }
+
+
+def reserve_execution_credits(
+    session: Session,
+    *,
+    execution_id: UUID,
+    user_id: UUID | None,
+    capability_definition_id: UUID | None,
+) -> AIUsageCharge | None:
+    effective = resolve_platform_policy(session)
+    if not effective.ai_controls_enabled or capability_definition_id is None:
+        return None
+    policy = session.get(AICapabilityPolicy, capability_definition_id)
+    if policy is None:
+        raise AccessPolicyError(
+            status_code=503,
+            code="ai_policy_unconfigured",
+            detail="This capability has not been classified by an administrator.",
+        )
+    if _value(policy.classification) == AICapabilityClassification.unmetered.value:
+        return None
+    if user_id is None:
+        raise AccessPolicyError(
+            status_code=403,
+            code="ai_not_entitled",
+            detail="Metered capabilities require a user entitlement.",
+        )
+
+    period = utc_month_start()
+    session.execute(
+        update(AIEntitlement)
+        .where(
+            AIEntitlement.user_id == user_id,
+            AIEntitlement.period_start != period,
+        )
+        .values(period_start=period, used_units=0)
+    )
+    entitlement = session.get(AIEntitlement, user_id)
+    if (
+        entitlement is None
+        or _value(entitlement.state) == AIEntitlementState.disabled.value
+    ):
+        raise AccessPolicyError(
+            status_code=403,
+            code="ai_not_entitled",
+            detail="AI access has not been enabled for this account.",
+        )
+
+    state = _value(entitlement.state)
+    conditions = [
+        AIEntitlement.user_id == user_id,
+        AIEntitlement.period_start == period,
+        AIEntitlement.state == entitlement.state,
+    ]
+    if state == AIEntitlementState.limited.value:
+        conditions.append(
+            AIEntitlement.used_units + policy.cost_units
+            <= AIEntitlement.monthly_limit_units
+        )
+    result = session.execute(
+        update(AIEntitlement)
+        .where(*conditions)
+        .values(used_units=AIEntitlement.used_units + policy.cost_units)
+    )
+    if result.rowcount != 1:
+        raise AccessPolicyError(
+            status_code=429,
+            code="ai_quota_exhausted",
+            detail="This account has reached its monthly AI credit limit.",
+            extra={"nextResetAt": next_utc_month_start(period).isoformat()},
+        )
+
+    charge = AIUsageCharge(
+        execution_id=execution_id,
+        user_id=user_id,
+        capability_definition_id=capability_definition_id,
+        units=policy.cost_units,
+        period_start=period,
+    )
+    session.add(charge)
+    session.flush()
+    return charge
+
+
+def usage_total_for_period(session: Session, period_start: date | None = None) -> int:
+    period = period_start or utc_month_start()
+    return int(
+        session.scalar(
+            select(func.coalesce(func.sum(AIUsageCharge.units), 0)).where(
+                AIUsageCharge.period_start == period
+            )
+        )
+        or 0
+    )
+
+
+__all__ = [
+    "AccessPolicyError",
+    "EffectivePlatformPolicy",
+    "authorize_registration",
+    "capability_cost_control",
+    "create_registration_invite",
+    "entitlement_payload",
+    "get_or_create_platform_policy",
+    "next_utc_month_start",
+    "normalize_admission_rule",
+    "read_platform_policy",
+    "reserve_execution_credits",
+    "resolve_platform_policy",
+    "usage_total_for_period",
+    "utc_month_start",
+]

--- a/src/fair_platform/backend/services/execution_store.py
+++ b/src/fair_platform/backend/services/execution_store.py
@@ -200,6 +200,14 @@ def create_execution(
     execution.submissions = submissions
     session.add(execution)
     session.flush()
+    from fair_platform.backend.services.access_control import reserve_execution_credits
+
+    reserve_execution_credits(
+        session,
+        execution_id=execution.id,
+        user_id=execution.initiated_by_user_id,
+        capability_definition_id=execution.capability_definition_id,
+    )
     if lineage_source is not None:
         inherited_artifacts = list(
             session.scalars(

--- a/src/fair_platform/backend/services/flow_runtime.py
+++ b/src/fair_platform/backend/services/flow_runtime.py
@@ -356,7 +356,11 @@ def advance_flow_execution(
 
 
 def fail_flow_execution(
-    session: Session, root_execution_id: UUID, error: str
+    session: Session,
+    root_execution_id: UUID,
+    error: str,
+    *,
+    error_code: str = "flow_runtime_error",
 ) -> FlowAdvanceResult:
     root = session.get(Execution, root_execution_id)
     if root is None or _value(root.kind) != ExecutionKind.flow.value:
@@ -372,7 +376,7 @@ def fail_flow_execution(
         session,
         root,
         status=ExecutionStatus.failed.value,
-        payload={"errorCode": "flow_runtime_error", "errorSummary": error},
+        payload={"errorCode": error_code, "errorSummary": error},
     )
 
 

--- a/src/fair_platform/cli/main.py
+++ b/src/fair_platform/cli/main.py
@@ -8,13 +8,18 @@ import sqlite3
 from collections import OrderedDict
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from uuid import uuid4
 
 import typer
 from typing_extensions import Annotated
 from fair_platform.backend.data.migrations import build_alembic_config
 from fair_platform.backend.api.routers.auth import hash_password
 from fair_platform.backend.data.database import SessionLocal
-from fair_platform.backend.data.models.user import User
+from fair_platform.backend.data.models.user import (
+    User,
+    UserRole,
+    normalize_email_address,
+)
 
 
 def _get_version() -> str:
@@ -91,7 +96,9 @@ def _run_server(host: str, port: int, headless: bool, dev: bool) -> None:
 
 def _start_backend_process(port: int, headless: bool) -> multiprocessing.Process:
     ctx = multiprocessing.get_context("spawn")
-    process = ctx.Process(target=_run_backend, kwargs={"port": port, "headless": headless})
+    process = ctx.Process(
+        target=_run_backend, kwargs={"port": port, "headless": headless}
+    )
     process.start()
     return process
 
@@ -360,7 +367,9 @@ def _migrate_sqlite_to_postgres(
     sqlite_conn.row_factory = sqlite3.Row
     migrated: OrderedDict[str, int] = OrderedDict()
 
-    pg_dsn_for_psycopg = normalized_target.replace("postgresql+psycopg://", "postgresql://", 1)
+    pg_dsn_for_psycopg = normalized_target.replace(
+        "postgresql+psycopg://", "postgresql://", 1
+    )
     pg_conn = psycopg.connect(pg_dsn_for_psycopg)
     pg_conn.autocommit = False
 
@@ -403,7 +412,9 @@ def _migrate_sqlite_to_postgres(
                 cols = list(rows[0].keys())
                 quoted_cols = ", ".join(f'"{c}"' for c in cols)
                 placeholders = ", ".join(["%s"] * len(cols))
-                insert_sql = f'INSERT INTO "{table}" ({quoted_cols}) VALUES ({placeholders})'
+                insert_sql = (
+                    f'INSERT INTO "{table}" ({quoted_cols}) VALUES ({placeholders})'
+                )
                 if on_conflict == "skip":
                     insert_sql += " ON CONFLICT DO NOTHING"
 
@@ -424,7 +435,9 @@ def _migrate_sqlite_to_postgres(
                                     parsed = v
                             else:
                                 parsed = v
-                            converted.append(Jsonb(parsed) if dtype == "jsonb" else parsed)
+                            converted.append(
+                                Jsonb(parsed) if dtype == "jsonb" else parsed
+                            )
                         elif dtype == "boolean" and isinstance(v, int):
                             converted.append(bool(v))
                         else:
@@ -470,10 +483,12 @@ def db_migrate_sqlite_to_postgres(
         str, typer.Option("--on-conflict", help="error|skip conflict handling")
     ] = "error",
     dry_run: Annotated[
-        bool, typer.Option("--dry-run", help="Parse and validate rows, but do not persist")
+        bool,
+        typer.Option("--dry-run", help="Parse and validate rows, but do not persist"),
     ] = False,
     verify: Annotated[
-        bool, typer.Option("--verify", help="Validate destination row counts after copy")
+        bool,
+        typer.Option("--verify", help="Validate destination row counts after copy"),
     ] = False,
 ):
     if on_conflict not in {"error", "skip"}:
@@ -508,6 +523,7 @@ def serve(
     # Check for updates unless disabled
     if not no_update_check:
         from fair_platform.utils.version import check_for_updates
+
         check_for_updates()
 
     _run_server(host="127.0.0.1", port=port, headless=headless, dev=False)
@@ -515,13 +531,17 @@ def serve(
 
 @app.command()
 def dev(
-    port: Annotated[int, typer.Option("--port", "-p", help="Backend port to use")] = 8000,
+    port: Annotated[
+        int, typer.Option("--port", "-p", help="Backend port to use")
+    ] = 8000,
     no_frontend: Annotated[
         bool, typer.Option("--no-frontend", help="Disable frontend dev server")
     ] = False,
     no_headless: Annotated[
         bool,
-        typer.Option("--no-headless", help="Serve the bundled frontend from the backend"),
+        typer.Option(
+            "--no-headless", help="Serve the bundled frontend from the backend"
+        ),
     ] = False,
 ):
     frontend_process = None
@@ -566,8 +586,16 @@ def reset_user_password(
         ),
     ],
 ):
+    try:
+        normalized_email = normalize_email_address(email)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
     with SessionLocal() as session:
-        user = session.query(User).filter(User.email == email).first()
+        user = (
+            session.query(User)
+            .filter(User.normalized_email == normalized_email)
+            .first()
+        )
         if user is None:
             typer.echo(f"User not found: {email}")
             raise typer.Exit(code=1)
@@ -577,6 +605,53 @@ def reset_user_password(
         session.commit()
 
     typer.echo(f"Password reset for {email}")
+
+
+@users_app.command("create-admin")
+def create_admin_user(
+    email: Annotated[str, typer.Argument(help="Email for the administrator")],
+    name: Annotated[str, typer.Option("--name", help="Administrator display name")],
+    password: Annotated[
+        str,
+        typer.Option(
+            "--password",
+            help="Password for the account",
+            prompt=True,
+            hide_input=True,
+            confirmation_prompt=True,
+        ),
+    ],
+):
+    """Create the first verified administrator without using public registration."""
+    if len(password) < 8:
+        raise typer.BadParameter("password must be at least 8 characters")
+    try:
+        normalized_email = normalize_email_address(email)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    with SessionLocal() as session:
+        existing = (
+            session.query(User)
+            .filter(User.normalized_email == normalized_email)
+            .first()
+        )
+        if existing is not None:
+            typer.echo(f"User already exists: {normalized_email}")
+            raise typer.Exit(code=1)
+        user = User(
+            id=uuid4(),
+            name=name.strip(),
+            email=email.strip(),
+            normalized_email=normalized_email,
+            role=UserRole.admin.value,
+            password_hash=hash_password(password),
+            is_verified=True,
+        )
+        session.add(user)
+        session.commit()
+
+    typer.echo(f"Administrator created: {normalized_email}")
 
 
 if __name__ == "__main__":

--- a/tests/execution_protocol_helpers.py
+++ b/tests/execution_protocol_helpers.py
@@ -49,7 +49,6 @@ def add_agent_capability(
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "type": "object",
             },
-            "requestedScopes": requested_scopes or [],
             "declaredEffects": [],
             "supportsStreaming": True,
             "supportsResume": supports_resume,

--- a/tests/test_access_controls.py
+++ b/tests/test_access_controls.py
@@ -1,0 +1,717 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import date, datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fair_platform.backend.data.models import (
+    AdmissionRule,
+    AdmissionRuleKind,
+    AICapabilityClassification,
+    AICapabilityPolicy,
+    AIEntitlement,
+    AIEntitlementState,
+    AIUsageCharge,
+    CapabilityDefinition,
+    Execution,
+    ExtensionInstallation,
+    PlatformPolicy,
+    RegistrationInvite,
+    User,
+)
+from fair_platform.backend.core.config import validate_security_configuration
+from fair_platform.backend.services.access_control import (
+    AccessPolicyError,
+    utc_month_start,
+)
+from fair_platform.backend.services.execution_store import create_execution
+from tests.conftest import create_sample_user_data, get_auth_token
+from tests.execution_protocol_helpers import add_agent_capability, execution_headers
+
+
+def _admin_headers(client: TestClient, admin_user) -> dict[str, str]:
+    token = get_auth_token(client, str(admin_user.email))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_open_registration_remains_the_upgrade_default(test_client, test_db):
+    response = test_client.post("/api/auth/register", json=create_sample_user_data())
+    assert response.status_code == 201
+    config = test_client.get("/api/v1/system/config").json()
+    assert config["registration"] == {"mode": "open", "invite_required": False}
+    assert config["features"]["ai_controls_enabled"] is False
+
+
+def test_allowlist_accepts_exact_domain_and_normalizes_identity(
+    test_client, test_db, admin_user
+):
+    with test_db() as session:
+        session.add_all(
+            [
+                PlatformPolicy(
+                    id=1, admission_mode="allowlist", ai_controls_enabled=False
+                ),
+                AdmissionRule(
+                    kind=AdmissionRuleKind.domain,
+                    normalized_value="example.edu",
+                    created_by_user_id=admin_user.id,
+                ),
+            ]
+        )
+        session.commit()
+
+    allowed = test_client.post(
+        "/api/auth/register",
+        json={
+            "name": "Allowed",
+            "email": "Allowed@EXAMPLE.edu",
+            "password": "password-123",
+        },
+    )
+    denied_subdomain = test_client.post(
+        "/api/auth/register",
+        json={
+            "name": "Denied",
+            "email": "denied@sub.example.edu",
+            "password": "password-123",
+        },
+    )
+
+    assert allowed.status_code == 201
+    assert denied_subdomain.status_code == 403
+    assert denied_subdomain.json()["code"] == "registration_not_permitted"
+    with test_db() as session:
+        row = (
+            session.query(User)
+            .filter(User.normalized_email == "allowed@example.edu")
+            .one()
+        )
+        assert str(row.email) == "Allowed@example.edu"
+
+
+def test_allowlist_supports_exact_individual_addresses(
+    test_client, test_db, admin_user
+):
+    with test_db() as session:
+        session.add_all(
+            [
+                PlatformPolicy(
+                    id=1, admission_mode="allowlist", ai_controls_enabled=False
+                ),
+                AdmissionRule(
+                    kind=AdmissionRuleKind.email,
+                    normalized_value="person@outside.example",
+                    created_by_user_id=admin_user.id,
+                ),
+            ]
+        )
+        session.commit()
+    response = test_client.post(
+        "/api/auth/register",
+        json={
+            "name": "Person",
+            "email": "PERSON@outside.example",
+            "password": "password-123",
+        },
+    )
+    assert response.status_code == 201
+
+
+def test_invitation_is_email_bound_single_use_and_does_not_verify_email(
+    test_client, test_db, admin_user, monkeypatch
+):
+    monkeypatch.setenv("FAIR_EMAIL_ENABLED", "1")
+    headers = _admin_headers(test_client, admin_user)
+    policy = test_client.patch(
+        "/api/v1/admin/platform-policy",
+        json={"admissionMode": "invite_only"},
+        headers=headers,
+    )
+    assert policy.status_code == 200
+    created = test_client.post(
+        "/api/v1/admin/invites",
+        json={"email": "invitee@example.edu", "expiresInDays": 7},
+        headers=headers,
+    )
+    assert created.status_code == 201
+    token = created.json()["token"]
+    assert token not in created.json()["registrationUrl"].split("#", 1)[0]
+
+    wrong_email = test_client.post(
+        "/api/auth/register",
+        json={
+            "name": "Wrong",
+            "email": "wrong@example.edu",
+            "password": "password-123",
+            "inviteToken": token,
+        },
+    )
+    assert wrong_email.status_code == 403
+    with test_db() as session:
+        assert (
+            session.query(User)
+            .filter(User.normalized_email == "invitee@example.edu")
+            .count()
+            == 0
+        )
+
+    accepted = test_client.post(
+        "/api/auth/register",
+        json={
+            "name": "Invitee",
+            "email": "INVITEE@example.edu",
+            "password": "password-123",
+            "inviteToken": token,
+        },
+    )
+    assert accepted.status_code == 201, accepted.text
+    reused = test_client.post(
+        "/api/auth/register",
+        json={
+            "name": "Again",
+            "email": "invitee@example.edu",
+            "password": "password-123",
+            "inviteToken": token,
+        },
+    )
+    assert reused.status_code in {400, 403}
+
+    with test_db() as session:
+        user = (
+            session.query(User)
+            .filter(User.normalized_email == "invitee@example.edu")
+            .one()
+        )
+        invite = session.query(RegistrationInvite).one()
+        assert user.is_verified is False
+        assert invite.redeemed_by_user_id == user.id
+        assert invite.token_hash != token
+
+
+def test_expired_and_revoked_invitations_fail_closed(test_client, test_db, admin_user):
+    expired_token = "expired-registration-token"
+    revoked_token = "revoked-registration-token"
+    now = datetime.now(timezone.utc)
+    with test_db() as session:
+        session.add(
+            PlatformPolicy(
+                id=1, admission_mode="invite_only", ai_controls_enabled=False
+            )
+        )
+        session.add_all(
+            [
+                RegistrationInvite(
+                    token_hash=hashlib.sha256(expired_token.encode()).hexdigest(),
+                    normalized_email="expired@example.edu",
+                    expires_at=now - timedelta(minutes=1),
+                    created_by_user_id=admin_user.id,
+                ),
+                RegistrationInvite(
+                    token_hash=hashlib.sha256(revoked_token.encode()).hexdigest(),
+                    normalized_email="revoked@example.edu",
+                    expires_at=now + timedelta(days=1),
+                    revoked_at=now,
+                    created_by_user_id=admin_user.id,
+                ),
+            ]
+        )
+        session.commit()
+    expired = test_client.post(
+        "/api/auth/register",
+        json={
+            "name": "Expired",
+            "email": "expired@example.edu",
+            "password": "password-123",
+            "inviteToken": expired_token,
+        },
+    )
+    revoked = test_client.post(
+        "/api/auth/register",
+        json={
+            "name": "Revoked",
+            "email": "revoked@example.edu",
+            "password": "password-123",
+            "inviteToken": revoked_token,
+        },
+    )
+    for response in (expired, revoked):
+        assert response.status_code == 403
+        assert response.json()["code"] == "registration_not_permitted"
+
+
+def test_admission_policy_does_not_block_existing_login(
+    test_client, test_db, student_user
+):
+    with test_db() as session:
+        session.add(
+            PlatformPolicy(
+                id=1, admission_mode="invite_only", ai_controls_enabled=False
+            )
+        )
+        session.commit()
+    response = test_client.post(
+        "/api/auth/login",
+        data={
+            "username": str(student_user.email).upper(),
+            "password": "test_password_123",
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_environment_policy_is_effective_and_admin_locked(
+    test_client, admin_user, monkeypatch
+):
+    monkeypatch.setenv("FAIR_ADMISSION_MODE", "invite_only")
+    monkeypatch.setenv("FAIR_AI_CONTROLS_ENABLED", "true")
+    headers = _admin_headers(test_client, admin_user)
+    read = test_client.get("/api/v1/admin/platform-policy", headers=headers)
+    assert read.status_code == 200
+    assert read.json()["effectiveAdmissionMode"] == "invite_only"
+    assert read.json()["admissionLocked"] is True
+    assert read.json()["aiControlsLocked"] is True
+    update = test_client.patch(
+        "/api/v1/admin/platform-policy",
+        json={"admissionMode": "open"},
+        headers=headers,
+    )
+    assert update.status_code == 409
+
+
+def test_database_managed_ai_controls_require_capability_classification(
+    test_client, test_db, admin_user
+):
+    with test_db() as session:
+        installation = ExtensionInstallation(extension_id="needs.classification")
+        add_agent_capability(session, installation)
+        session.commit()
+    response = test_client.patch(
+        "/api/v1/admin/platform-policy",
+        json={"aiControlsEnabled": True},
+        headers=_admin_headers(test_client, admin_user),
+    )
+    assert response.status_code == 409
+    assert "1 unclassified" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "message"),
+    [
+        ("FAIR_ADMISSION_MODE", "private", "must be one of"),
+        ("FAIR_AI_CONTROLS_ENABLED", "sometimes", "must be a boolean"),
+    ],
+)
+def test_invalid_policy_environment_values_fail_startup(
+    monkeypatch, name, value, message
+):
+    monkeypatch.delenv("FAIR_ADMISSION_MODE", raising=False)
+    monkeypatch.delenv("FAIR_AI_CONTROLS_ENABLED", raising=False)
+    monkeypatch.setenv(name, value)
+    with pytest.raises(RuntimeError, match=message):
+        validate_security_configuration("configured-secret")
+
+
+def _seed_metered_capability(
+    test_db,
+    user,
+    admin_user,
+    *,
+    controls_enabled=True,
+    state="limited",
+    limit=3,
+    cost=2,
+):
+    with test_db() as session:
+        installation = ExtensionInstallation(extension_id=f"metered.{uuid4()}")
+        capability = add_agent_capability(session, installation)
+        session.add(
+            PlatformPolicy(
+                id=1, admission_mode="open", ai_controls_enabled=controls_enabled
+            )
+        )
+        session.add(
+            AICapabilityPolicy(
+                capability_definition_id=capability.id,
+                classification=AICapabilityClassification.ai,
+                cost_units=cost,
+                updated_by_user_id=admin_user.id,
+            )
+        )
+        session.add(
+            AIEntitlement(
+                user_id=user.id,
+                state=AIEntitlementState(state),
+                monthly_limit_units=limit if state == "limited" else None,
+                used_units=0,
+                period_start=date.today().replace(day=1),
+                updated_by_user_id=admin_user.id,
+            )
+        )
+        session.commit()
+        return capability.id, installation.id
+
+
+def test_weighted_credits_are_reserved_before_execution_dispatch(
+    test_db, student_user, admin_user
+):
+    capability_id, installation_id = _seed_metered_capability(
+        test_db, student_user, admin_user
+    )
+    with test_db() as session:
+        first = create_execution(
+            session,
+            kind="agent",
+            initiated_by_user_id=student_user.id,
+            capability_definition_id=capability_id,
+            extension_installation_id=installation_id,
+        )
+        session.commit()
+        assert first.id is not None
+
+    with test_db() as session:
+        with pytest.raises(AccessPolicyError) as captured:
+            create_execution(
+                session,
+                kind="agent",
+                initiated_by_user_id=student_user.id,
+                capability_definition_id=capability_id,
+                extension_installation_id=installation_id,
+            )
+        assert captured.value.code == "ai_quota_exhausted"
+        session.rollback()
+
+    with test_db() as session:
+        entitlement = session.get(AIEntitlement, student_user.id)
+        assert entitlement.used_units == 2
+        assert session.query(AIUsageCharge).count() == 1
+
+
+def test_controls_disabled_preserve_existing_execution_behavior(
+    test_db, student_user, admin_user
+):
+    capability_id, installation_id = _seed_metered_capability(
+        test_db, student_user, admin_user, controls_enabled=False
+    )
+    with test_db() as session:
+        create_execution(
+            session,
+            kind="agent",
+            initiated_by_user_id=student_user.id,
+            capability_definition_id=capability_id,
+            extension_installation_id=installation_id,
+        )
+        session.commit()
+        assert session.query(AIUsageCharge).count() == 0
+
+
+def test_stale_monthly_counter_resets_before_atomic_reservation(
+    test_db, student_user, admin_user
+):
+    capability_id, installation_id = _seed_metered_capability(
+        test_db, student_user, admin_user
+    )
+    with test_db() as session:
+        entitlement = session.get(AIEntitlement, student_user.id)
+        entitlement.period_start = date(2000, 1, 1)
+        entitlement.used_units = entitlement.monthly_limit_units
+        session.commit()
+
+    with test_db() as session:
+        create_execution(
+            session,
+            kind="agent",
+            initiated_by_user_id=student_user.id,
+            capability_definition_id=capability_id,
+            extension_installation_id=installation_id,
+        )
+        session.commit()
+        entitlement = session.get(AIEntitlement, student_user.id)
+        assert entitlement.period_start == utc_month_start()
+        assert entitlement.used_units == 2
+        assert session.query(AIUsageCharge).count() == 1
+
+
+def test_unclassified_capability_fails_closed_when_controls_enabled(
+    test_db, student_user, admin_user
+):
+    with test_db() as session:
+        installation = ExtensionInstallation(extension_id="unclassified.agent")
+        capability = add_agent_capability(session, installation)
+        session.add(
+            PlatformPolicy(id=1, admission_mode="open", ai_controls_enabled=True)
+        )
+        session.commit()
+        capability_id = capability.id
+        installation_id = installation.id
+    with test_db() as session:
+        with pytest.raises(AccessPolicyError) as captured:
+            create_execution(
+                session,
+                kind="agent",
+                initiated_by_user_id=student_user.id,
+                capability_definition_id=capability_id,
+                extension_installation_id=installation_id,
+            )
+        assert captured.value.code == "ai_policy_unconfigured"
+
+
+def test_unlimited_entitlement_is_still_audited(test_db, student_user, admin_user):
+    capability_id, installation_id = _seed_metered_capability(
+        test_db, student_user, admin_user, state="unlimited", limit=None, cost=5
+    )
+    with test_db() as session:
+        create_execution(
+            session,
+            kind="agent",
+            initiated_by_user_id=student_user.id,
+            capability_definition_id=capability_id,
+            extension_installation_id=installation_id,
+        )
+        session.commit()
+        entitlement = session.get(AIEntitlement, student_user.id)
+        assert entitlement.used_units == 5
+        assert session.query(AIUsageCharge).one().units == 5
+
+
+def test_unmetered_capability_requires_no_entitlement(
+    test_db, student_user, admin_user
+):
+    with test_db() as session:
+        installation = ExtensionInstallation(extension_id="unmetered.agent")
+        capability = add_agent_capability(session, installation)
+        session.add(
+            PlatformPolicy(id=1, admission_mode="open", ai_controls_enabled=True)
+        )
+        session.add(
+            AICapabilityPolicy(
+                capability_definition_id=capability.id,
+                classification=AICapabilityClassification.unmetered,
+                cost_units=0,
+                updated_by_user_id=admin_user.id,
+            )
+        )
+        session.commit()
+        create_execution(
+            session,
+            kind="agent",
+            initiated_by_user_id=student_user.id,
+            capability_definition_id=capability.id,
+            extension_installation_id=installation.id,
+        )
+        session.commit()
+        assert session.query(AIUsageCharge).count() == 0
+
+
+def test_admin_endpoints_require_admin(test_client, student_user):
+    token = get_auth_token(test_client, str(student_user.email))
+    response = test_client.get(
+        "/api/v1/admin/platform-policy",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 403
+
+
+def test_user_can_read_only_their_own_entitlement(
+    test_client, test_db, student_user, admin_user
+):
+    _seed_metered_capability(test_db, student_user, admin_user)
+    token = get_auth_token(test_client, str(student_user.email))
+    response = test_client.get(
+        "/api/v1/ai/entitlement",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["state"] == "limited"
+    assert response.json()["monthlyLimitUnits"] == 3
+
+
+def test_admin_workflow_surfaces_cost_and_complete_filtered_usage(
+    test_client, test_db, student_user, admin_user
+):
+    with test_db() as session:
+        installation = ExtensionInstallation(extension_id="admin.workflow.agent")
+        capability = add_agent_capability(session, installation)
+        session.commit()
+        capability_id = capability.id
+        installation_id = installation.id
+
+    admin_headers = _admin_headers(test_client, admin_user)
+    policies = test_client.get(
+        "/api/v1/admin/capability-cost-policies", headers=admin_headers
+    )
+    assert policies.status_code == 200
+    assert policies.json()[0]["classification"] == "unclassified"
+    classified = test_client.put(
+        f"/api/v1/admin/capability-cost-policies/{capability_id}",
+        json={"classification": "ai", "costUnits": 2},
+        headers=admin_headers,
+    )
+    assert classified.status_code == 200
+    entitlement = test_client.put(
+        f"/api/v1/admin/users/{student_user.id}/ai-entitlement",
+        json={"state": "limited", "monthlyLimitUnits": 5},
+        headers=admin_headers,
+    )
+    assert entitlement.status_code == 200
+    enabled = test_client.patch(
+        "/api/v1/admin/platform-policy",
+        json={"aiControlsEnabled": True},
+        headers=admin_headers,
+    )
+    assert enabled.status_code == 200
+
+    student_headers = {
+        "Authorization": f"Bearer {get_auth_token(test_client, str(student_user.email))}"
+    }
+    available = test_client.get(
+        "/api/v1/extensions/capabilities", headers=student_headers
+    )
+    assert available.status_code == 200
+    assert available.json()[0]["costControl"] == {
+        "controlsEnabled": True,
+        "classification": "ai",
+        "costUnits": 2,
+        "executable": True,
+        "reason": None,
+    }
+
+    with test_db() as session:
+        for _ in range(2):
+            create_execution(
+                session,
+                kind="agent",
+                initiated_by_user_id=student_user.id,
+                capability_definition_id=capability_id,
+                extension_installation_id=installation_id,
+            )
+            session.commit()
+
+    exhausted = test_client.get(
+        "/api/v1/extensions/capabilities", headers=student_headers
+    ).json()[0]["costControl"]
+    assert exhausted["executable"] is False
+    assert exhausted["reason"] == "ai_quota_exhausted"
+    usage = test_client.get(
+        f"/api/v1/admin/ai-usage?user_id={student_user.id}&limit=1",
+        headers=admin_headers,
+    )
+    assert usage.status_code == 200
+    assert usage.json()["totalUnits"] == 4
+    assert len(usage.json()["charges"]) == 1
+
+
+def test_later_flow_step_quota_denial_fails_root_without_dispatch(
+    test_client, test_db, student_user, admin_user
+):
+    extension_id = "metered.flow-extension"
+    with test_db() as session:
+        installation = ExtensionInstallation(
+            extension_id=extension_id,
+            display_name="Metered Flow Extension",
+            version="1.0.0",
+        )
+        session.add(installation)
+        session.flush()
+        capability = CapabilityDefinition(
+            installation_id=installation.id,
+            capability_id="metered.transform",
+            surface="function",
+            version="1.0.0",
+            declared_effects=[],
+            manifest_snapshot={
+                "capabilityId": "metered.transform",
+                "kind": "action",
+                "version": "1.0.0",
+                "inputSchema": {"type": "object"},
+                "outputSchema": {"type": "object"},
+            },
+        )
+        session.add(capability)
+        session.flush()
+        session.add_all(
+            [
+                PlatformPolicy(id=1, admission_mode="open", ai_controls_enabled=True),
+                AICapabilityPolicy(
+                    capability_definition_id=capability.id,
+                    classification=AICapabilityClassification.ai,
+                    cost_units=2,
+                    updated_by_user_id=admin_user.id,
+                ),
+                AIEntitlement(
+                    user_id=student_user.id,
+                    state=AIEntitlementState.limited,
+                    monthly_limit_units=2,
+                    used_units=0,
+                    period_start=date.today().replace(day=1),
+                    updated_by_user_id=admin_user.id,
+                ),
+            ]
+        )
+        session.commit()
+        capability_id = capability.id
+
+    headers = {
+        "Authorization": f"Bearer {get_auth_token(test_client, str(student_user.email))}"
+    }
+    flow = test_client.post(
+        "/api/v1/flows", json={"name": "Quota Flow"}, headers=headers
+    )
+    assert flow.status_code == 201, flow.text
+    version = test_client.post(
+        f"/api/v1/flows/{flow.json()['id']}/versions",
+        json={
+            "definition": {
+                "mode": "ordered",
+                "nodes": [
+                    {"id": "first", "capabilityDefinitionId": str(capability_id)},
+                    {"id": "second", "capabilityDefinitionId": str(capability_id)},
+                ],
+            }
+        },
+        headers=headers,
+    )
+    assert version.status_code == 201, version.text
+    published = test_client.post(
+        f"/api/v1/flows/{flow.json()['id']}/versions/{version.json()['id']}/publish",
+        headers=headers,
+    )
+    assert published.status_code == 200, published.text
+    started = test_client.post(
+        f"/api/v1/flows/{flow.json()['id']}/executions",
+        json={},
+        headers=headers,
+    )
+    assert started.status_code == 202, started.text
+    root_id = started.json()["executionId"]
+    first_id = started.json()["stepExecutionId"]
+
+    completed = test_client.post(
+        f"/api/v1/executions/{first_id}/events/ingest",
+        headers=execution_headers(test_db, first_id),
+        json={
+            "events": [
+                {
+                    "producerSource": extension_id,
+                    "producerEventId": "first-completed",
+                    "type": "execution.completed",
+                    "schemaUri": "urn:fair:event:execution.completed:v1",
+                    "occurredAt": datetime.now(timezone.utc).isoformat(),
+                    "visibility": "user",
+                    "payload": {"outputSummary": {"value": 1}},
+                }
+            ]
+        },
+    )
+    assert completed.status_code == 202, completed.text
+    with test_db() as session:
+        root = session.get(Execution, UUID(root_id))
+        children = list(
+            session.query(Execution).filter(Execution.parent_execution_id == root.id)
+        )
+        assert root.status == "failed"
+        assert root.error_code == "ai_quota_exhausted"
+        assert [child.flow_node_id for child in children] == ["first"]
+        assert session.query(AIUsageCharge).count() == 1

--- a/tests/test_auth_integration.py
+++ b/tests/test_auth_integration.py
@@ -119,7 +119,7 @@ class TestAuthenticationFlow:
 
         logout_response = test_client.post("/api/auth/logout")
         assert logout_response.status_code == 200
-        assert "fair_session=\"\"" in logout_response.headers["set-cookie"]
+        assert 'fair_session=""' in logout_response.headers["set-cookie"]
         assert "Max-Age=0" in logout_response.headers["set-cookie"]
         assert test_client.get("/api/auth/me").status_code == 401
 
@@ -201,9 +201,7 @@ class TestAuthenticationFlow:
             json=user_data,
         )
 
-        assert response.status_code == 201, (
-            f"User creation failed: {response.text}"
-        )
+        assert response.status_code == 201, f"User creation failed: {response.text}"
 
         response_data = response.json()
 
@@ -222,14 +220,46 @@ class TestAuthenticationFlow:
         assert "name" in user, "Name should be in response"
         assert "role" in user, "Role should be in response"
 
-    def test_auth_me_capabilities_matrix_by_role_and_mode(self, test_client: TestClient, test_db, monkeypatch):
+    def test_auth_me_capabilities_matrix_by_role_and_mode(
+        self, test_client: TestClient, test_db, monkeypatch
+    ):
         scenarios = [
-            ("COMMUNITY", UserRole.admin.value, {"manage_users", "cleanup_orphaned_artifacts"}, set()),
-            ("ENTERPRISE", UserRole.admin.value, {"manage_users", "cleanup_orphaned_artifacts"}, set()),
-            ("COMMUNITY", UserRole.instructor.value, {"create_flow", "read_executions"}, {"cleanup_orphaned_artifacts"}),
-            ("ENTERPRISE", UserRole.instructor.value, {"create_flow", "read_executions"}, {"cleanup_orphaned_artifacts"}),
-            ("COMMUNITY", UserRole.user.value, {"join_course", "create_flow", "read_executions"}, set()),
-            ("ENTERPRISE", UserRole.user.value, {"join_course"}, {"create_flow", "read_executions"}),
+            (
+                "COMMUNITY",
+                UserRole.admin.value,
+                {"manage_users", "cleanup_orphaned_artifacts"},
+                set(),
+            ),
+            (
+                "ENTERPRISE",
+                UserRole.admin.value,
+                {"manage_users", "cleanup_orphaned_artifacts"},
+                set(),
+            ),
+            (
+                "COMMUNITY",
+                UserRole.instructor.value,
+                {"create_flow", "read_executions"},
+                {"cleanup_orphaned_artifacts"},
+            ),
+            (
+                "ENTERPRISE",
+                UserRole.instructor.value,
+                {"create_flow", "read_executions"},
+                {"cleanup_orphaned_artifacts"},
+            ),
+            (
+                "COMMUNITY",
+                UserRole.user.value,
+                {"join_course", "create_flow", "read_executions"},
+                set(),
+            ),
+            (
+                "ENTERPRISE",
+                UserRole.user.value,
+                {"join_course"},
+                {"create_flow", "read_executions"},
+            ),
         ]
 
         for mode, role, expected_present, expected_missing in scenarios:
@@ -267,7 +297,9 @@ class TestAuthenticationFlow:
             for capability in expected_missing:
                 assert capability not in capabilities
 
-    def test_auth_me_normalizes_legacy_role_aliases_from_db(self, test_client: TestClient, test_db):
+    def test_auth_me_normalizes_legacy_role_aliases_from_db(
+        self, test_client: TestClient, test_db
+    ):
         with test_db() as session:
             legacy_student = User(
                 id=uuid4(),
@@ -305,7 +337,9 @@ class TestAuthenticationFlow:
             payload = me_response.json()
             assert payload["role"] == expected_role
 
-    def test_auth_me_preferences_are_loaded_from_user_settings(self, test_client: TestClient, test_db):
+    def test_auth_me_preferences_are_loaded_from_user_settings(
+        self, test_client: TestClient, test_db
+    ):
         email = f"settings-{uuid4()}@test.com"
         with test_db() as session:
             user = User(
@@ -334,7 +368,9 @@ class TestAuthenticationFlow:
         payload = me_response.json()
         assert payload["settings"]["preferences"]["interfaceMode"] == "expert"
 
-    def test_user_can_get_and_update_own_settings(self, test_client: TestClient, student_user, test_db):
+    def test_user_can_get_and_update_own_settings(
+        self, test_client: TestClient, student_user, test_db
+    ):
         login_response = test_client.post(
             "/api/auth/login",
             data={"username": student_user.email, "password": "test_password_123"},
@@ -373,7 +409,9 @@ class TestAuthenticationFlow:
                 "ui": {"show_tips": False},
             }
 
-    def test_user_settings_patch_rejects_conflicting_casing(self, test_client: TestClient, student_user):
+    def test_user_settings_patch_rejects_conflicting_casing(
+        self, test_client: TestClient, student_user
+    ):
         login_response = test_client.post(
             "/api/auth/login",
             data={"username": student_user.email, "password": "test_password_123"},
@@ -396,13 +434,21 @@ class TestAuthenticationFlow:
             headers=headers,
         )
         assert update_response.status_code == 422
-        assert "Conflicting keys normalize to 'interface_mode'" in update_response.json()["detail"]
+        assert (
+            "Conflicting keys normalize to 'interface_mode'"
+            in update_response.json()["detail"]
+        )
 
-    def test_system_config_exposes_email_capability(self, test_client: TestClient, monkeypatch):
+    def test_system_config_exposes_email_capability(
+        self, test_client: TestClient, monkeypatch
+    ):
         monkeypatch.setenv("FAIR_EMAIL_ENABLED", "1")
         response = test_client.get("/api/v1/system/config")
         assert response.status_code == 200
-        assert response.json() == {"features": {"email_enabled": True}}
+        assert response.json() == {
+            "features": {"email_enabled": True, "ai_controls_enabled": False},
+            "registration": {"mode": "open", "invite_required": False},
+        }
 
     def test_system_config_enables_email_when_resend_key_present(
         self,
@@ -413,7 +459,10 @@ class TestAuthenticationFlow:
         monkeypatch.setenv("RESEND_API_KEY", "re_live_example")
         response = test_client.get("/api/v1/system/config")
         assert response.status_code == 200
-        assert response.json() == {"features": {"email_enabled": True}}
+        assert response.json() == {
+            "features": {"email_enabled": True, "ai_controls_enabled": False},
+            "registration": {"mode": "open", "invite_required": False},
+        }
 
     def test_register_auto_verifies_when_email_disabled(
         self, test_client: TestClient, test_db, monkeypatch
@@ -424,7 +473,9 @@ class TestAuthenticationFlow:
         assert response.status_code == 201
 
         with test_db() as session:
-            created = session.query(User).filter(User.email == user_data["email"]).first()
+            created = (
+                session.query(User).filter(User.email == user_data["email"]).first()
+            )
             assert created is not None
             assert created.is_verified is True
 
@@ -437,7 +488,9 @@ class TestAuthenticationFlow:
         assert response.status_code == 201
 
         with test_db() as session:
-            created = session.query(User).filter(User.email == user_data["email"]).first()
+            created = (
+                session.query(User).filter(User.email == user_data["email"]).first()
+            )
             assert created is not None
             assert created.is_verified is False
 
@@ -479,7 +532,10 @@ class TestAuthenticationFlow:
             data={"username": email, "password": password},
         )
         assert login_response.status_code == 403
-        assert login_response.json()["detail"] == "Please verify your email before signing in"
+        assert (
+            login_response.json()["detail"]
+            == "Please verify your email before signing in"
+        )
 
     def test_login_allows_unverified_user_when_enforcement_disabled(
         self, test_client: TestClient, test_db, monkeypatch
@@ -530,7 +586,9 @@ class TestAuthenticationFlow:
                 expires_delta=timedelta(hours=1),
             )
 
-        verify_response = test_client.post("/api/auth/verify-email/confirm", json={"token": token})
+        verify_response = test_client.post(
+            "/api/auth/verify-email/confirm", json={"token": token}
+        )
         assert verify_response.status_code == 200
 
         login_response = test_client.post(
@@ -548,7 +606,9 @@ class TestAuthenticationFlow:
             json={"email": "student@test.com"},
         )
         assert response.status_code == 400
-        assert response.json()["detail"] == "Email services are disabled on this instance"
+        assert (
+            response.json()["detail"] == "Email services are disabled on this instance"
+        )
 
     def test_resend_verification_returns_400_when_email_disabled(
         self, test_client: TestClient, student_user, monkeypatch
@@ -566,7 +626,9 @@ class TestAuthenticationFlow:
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 400
-        assert response.json()["detail"] == "Email services are disabled on this instance"
+        assert (
+            response.json()["detail"] == "Email services are disabled on this instance"
+        )
 
     def test_public_resend_verification_request_returns_400_when_email_disabled(
         self,
@@ -579,7 +641,9 @@ class TestAuthenticationFlow:
             json={"email": "student@test.com"},
         )
         assert response.status_code == 400
-        assert response.json()["detail"] == "Email services are disabled on this instance"
+        assert (
+            response.json()["detail"] == "Email services are disabled on this instance"
+        )
 
     def test_public_resend_verification_request_uses_generic_response_and_only_sends_for_unverified(
         self,
@@ -620,9 +684,7 @@ class TestAuthenticationFlow:
             )
             session.commit()
 
-        generic_message = (
-            "If an account exists and requires verification, a verification email has been sent"
-        )
+        generic_message = "If an account exists and requires verification, a verification email has been sent"
         for email in ("missing@test.com", verified_email, unverified_email):
             response = test_client.post(
                 "/api/auth/resend-verification-request",
@@ -635,7 +697,9 @@ class TestAuthenticationFlow:
         assert sent[0][0] == unverified_email
         assert "verify-email?token=" in sent[0][1]
 
-    def test_verify_email_confirm_marks_user_verified(self, test_client: TestClient, test_db):
+    def test_verify_email_confirm_marks_user_verified(
+        self, test_client: TestClient, test_db
+    ):
         with test_db() as session:
             user = User(
                 id=uuid4(),
@@ -653,7 +717,9 @@ class TestAuthenticationFlow:
                 expires_delta=timedelta(hours=1),
             )
 
-        response = test_client.post("/api/auth/verify-email/confirm", json={"token": token})
+        response = test_client.post(
+            "/api/auth/verify-email/confirm", json={"token": token}
+        )
         assert response.status_code == 200
         assert response.json()["detail"] == "Email verified successfully"
 
@@ -680,11 +746,15 @@ class TestAuthenticationFlow:
                 expires_delta=timedelta(hours=1),
             )
 
-        first_response = test_client.post("/api/auth/verify-email/confirm", json={"token": token})
+        first_response = test_client.post(
+            "/api/auth/verify-email/confirm", json={"token": token}
+        )
         assert first_response.status_code == 200
         assert first_response.json()["detail"] == "Email verified successfully"
 
-        second_response = test_client.post("/api/auth/verify-email/confirm", json={"token": token})
+        second_response = test_client.post(
+            "/api/auth/verify-email/confirm", json={"token": token}
+        )
         assert second_response.status_code == 200
         assert second_response.json()["detail"] == "Email already verified"
         assert "access_token" in second_response.json()
@@ -711,7 +781,9 @@ class TestAuthenticationFlow:
                 expires_delta=timedelta(hours=1),
             )
 
-        verify_response = test_client.post("/api/auth/verify-email/confirm", json={"token": token})
+        verify_response = test_client.post(
+            "/api/auth/verify-email/confirm", json={"token": token}
+        )
         assert verify_response.status_code == 200
         access_token = verify_response.json()["access_token"]
 
@@ -722,7 +794,9 @@ class TestAuthenticationFlow:
         assert me_response.status_code == 200
         assert me_response.json()["email"] == user.email
 
-    def test_reset_password_confirm_updates_password_hash(self, test_client: TestClient, test_db):
+    def test_reset_password_confirm_updates_password_hash(
+        self, test_client: TestClient, test_db
+    ):
         email = f"reset-{uuid4()}@test.com"
         with test_db() as session:
             user = User(
@@ -754,7 +828,9 @@ class TestAuthenticationFlow:
         )
         assert login_response.status_code == 200
 
-    def test_verify_and_reset_confirm_reject_invalid_tokens(self, test_client: TestClient):
+    def test_verify_and_reset_confirm_reject_invalid_tokens(
+        self, test_client: TestClient
+    ):
         verify_response = test_client.post(
             "/api/auth/verify-email/confirm",
             json={"token": "invalid-token"},

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -234,7 +234,10 @@ def test_db_migrate_sqlite_to_postgres_invokes_copy(monkeypatch):
 
     assert result.exit_code == 0
     assert captured["from_sqlite"] == Path("new.db")
-    assert captured["to_postgres"] == "postgresql://postgres:postgres@localhost:55432/postgres"
+    assert (
+        captured["to_postgres"]
+        == "postgresql://postgres:postgres@localhost:55432/postgres"
+    )
     assert captured["on_conflict"] == "skip"
     assert captured["dry_run"] is True
     assert captured["verify"] is True
@@ -286,6 +289,7 @@ class _FakeSession:
     def __init__(self, user):
         self.user = user
         self.committed = False
+        self.added = []
 
     def __enter__(self):
         return self
@@ -296,8 +300,8 @@ class _FakeSession:
     def query(self, _model):
         return _FakeQuery(self.user)
 
-    def add(self, _item):
-        return None
+    def add(self, item):
+        self.added.append(item)
 
     def commit(self):
         self.committed = True
@@ -315,7 +319,9 @@ def test_users_reset_password_updates_hash(monkeypatch):
     fake_session = _FakeSession(fake_user)
 
     monkeypatch.setattr(cli_main, "SessionLocal", lambda: fake_session)
-    monkeypatch.setattr(cli_main, "hash_password", lambda password: f"hashed::{password}")
+    monkeypatch.setattr(
+        cli_main, "hash_password", lambda password: f"hashed::{password}"
+    )
 
     result = runner.invoke(
         cli_main.app,
@@ -326,6 +332,38 @@ def test_users_reset_password_updates_hash(monkeypatch):
     assert fake_user.password_hash == "hashed::new-secret"
     assert fake_session.committed is True
     assert "Password reset for student@test.com" in result.output
+
+
+def test_users_create_admin_bootstraps_verified_account(monkeypatch):
+    runner = CliRunner()
+    fake_session = _FakeSession(None)
+
+    monkeypatch.setattr(cli_main, "SessionLocal", lambda: fake_session)
+    monkeypatch.setattr(
+        cli_main, "hash_password", lambda password: f"hashed::{password}"
+    )
+
+    result = runner.invoke(
+        cli_main.app,
+        [
+            "users",
+            "create-admin",
+            "ADMIN@EXAMPLE.edu",
+            "--name",
+            "Bootstrap Admin",
+            "--password",
+            "safe-password",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake_session.committed is True
+    assert len(fake_session.added) == 1
+    created = fake_session.added[0]
+    assert created.normalized_email == "admin@example.edu"
+    assert created.role == "admin"
+    assert created.is_verified is True
+    assert created.password_hash == "hashed::safe-password"
 
 
 def test_users_reset_password_returns_error_for_unknown_email(monkeypatch):

--- a/tests/test_migration_rehearsal_files.py
+++ b/tests/test_migration_rehearsal_files.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import sqlite3
 from pathlib import Path
+from uuid import uuid4
 
 from alembic import command
 from alembic.migration import MigrationContext
@@ -63,6 +64,82 @@ def test_upgrade_rehearsal_head_to_head_is_idempotent(tmp_path: Path) -> None:
 
     assert first == _alembic_head()
     assert second == first
+
+
+def _insert_pre_identity_user(connection, *, email: str) -> None:
+    connection.execute(
+        text(
+            """
+            INSERT INTO users (
+                id, name, email, role, password_hash, is_verified, settings
+            ) VALUES (
+                :id, :name, :email, 'user', NULL, 1, '{}'
+            )
+            """
+        ),
+        {"id": uuid4().hex, "name": email, "email": email},
+    )
+
+
+def test_admission_migration_backfills_normalized_email_and_tables(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "admission_backfill.sqlite"
+    database_url = f"sqlite:///{db_path.as_posix()}"
+    run_migrations_to_revision("20260727_0028", database_url)
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        _insert_pre_identity_user(connection, email="Person@EXAMPLE.edu")
+    engine.dispose()
+
+    run_migrations_to_head(database_url)
+
+    engine = create_engine(database_url)
+    with engine.connect() as connection:
+        schema = inspect(connection)
+        assert connection.scalar(text("SELECT normalized_email FROM users")) == (
+            "person@example.edu"
+        )
+        assert {
+            "platform_policies",
+            "admission_rules",
+            "registration_invites",
+            "ai_capability_policies",
+            "ai_entitlements",
+            "ai_usage_charges",
+        } <= set(schema.get_table_names())
+        assert {column["name"] for column in schema.get_columns("users")} >= {
+            "email",
+            "normalized_email",
+        }
+    engine.dispose()
+
+
+def test_admission_migration_refuses_normalized_email_collision(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "admission_collision.sqlite"
+    database_url = f"sqlite:///{db_path.as_posix()}"
+    run_migrations_to_revision("20260727_0028", database_url)
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        _insert_pre_identity_user(connection, email="same@EXAMPLE.edu")
+        _insert_pre_identity_user(connection, email="SAME@example.edu")
+    engine.dispose()
+
+    with pytest.raises(RuntimeError, match="normalized email collisions"):
+        run_migrations_to_head(database_url)
+
+    engine = create_engine(database_url)
+    with engine.connect() as connection:
+        # The intervening LMS migrations commit successfully; the admission
+        # revision itself fails before stamping its new head.
+        assert _read_revision(db_path) == "20260812_0034"
+        assert "normalized_email" not in {
+            column["name"] for column in inspect(connection).get_columns("users")
+        }
+        assert connection.scalar(text("SELECT COUNT(*) FROM users")) == 2
+    engine.dispose()
 
 
 def test_upgrade_rehearsal_from_pre_merge_lms_head(tmp_path: Path) -> None:

--- a/tests/test_quiz_migration.py
+++ b/tests/test_quiz_migration.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from alembic import command
+from alembic.script import ScriptDirectory
 from sqlalchemy import UUID as SAUUID
 from sqlalchemy import MetaData, create_engine, inspect, select
 
@@ -18,7 +19,6 @@ from fair_platform.backend.data.migrations import (
 
 A3_REVISION = "20260812_0031"
 A4_REVISION = "20260812_0032"
-A8_REVISION = "20260812_0034"
 QUIZ_TABLES = {
     "question_banks",
     "questions",
@@ -38,6 +38,11 @@ def _revision(path: Path) -> str:
         ).fetchone()
     assert row is not None
     return row[0]
+
+
+def _alembic_head() -> str:
+    script = ScriptDirectory.from_config(build_alembic_config("sqlite:///:memory:"))
+    return script.get_current_head()
 
 
 def test_quiz_migration_upgrades_downgrades_and_reupgrades(tmp_path: Path) -> None:
@@ -74,7 +79,7 @@ def test_quiz_migration_upgrades_downgrades_and_reupgrades(tmp_path: Path) -> No
     engine.dispose()
 
     run_migrations_to_head(database_url)
-    assert _revision(path) == A8_REVISION
+    assert _revision(path) == _alembic_head()
     engine = create_engine(database_url)
     schema = inspect(engine)
     assert "course_templates" in schema.get_table_names()
@@ -356,7 +361,7 @@ def test_populated_quiz_downgrade_removes_only_a4_generic_projections(
     engine.dispose()
 
     run_migrations_to_head(database_url)
-    assert _revision(path) == A8_REVISION
+    assert _revision(path) == _alembic_head()
 
 
 def test_quiz_migration_is_explicit_and_stacked_on_gradebook() -> None:


### PR DESCRIPTION
## Summary

- Add deployment-neutral admission modes: open registration, exact approved domains or email addresses, and email-bound invite-only registration.
- Separate admission from AI access with disabled, limited, and unlimited per-user entitlements plus operator-defined monthly weighted credits.
- Reserve AI credits atomically in the central execution path before dispatch, including later Flow steps, and expose immutable usage audit records.
- Add admin APIs and Settings UI for policies, rules, invites, capability classification, entitlements, and usage review.
- Keep existing deployments compatible with open registration and AI controls disabled unless an operator opts in; environment overrides remain authoritative and lock the corresponding UI controls.
- Correct English and Spanish documentation so the former public community instance is described as currently offline and not guaranteed to return.

## Security and compatibility

- Normalize email identity with case-folding and IDNA before admission checks and uniqueness enforcement.
- Store only invite token hashes; invitations are email-bound, expiring, revocable, and single-use.
- Preserve existing logins and roles. Public registration can no longer self-assign a privileged role.
- Require every installed capability to be classified before database-managed AI controls can be enabled; enabled controls fail closed for unclassified capabilities.
- Document that domain allowlisting proves only the submitted address unless email verification is enforced.
- Treat weighted credits as request weights, not provider tokens, currency, invoice reconciliation, or a guaranteed dollar ceiling.
- Deliberately omit application-level IP allowlisting from v1; operators should use reverse-proxy or WAF rate limits and monitoring.

## Validation

- `ruff check` and `ruff format --check` pass for all changed Python files.
- Alembic reports one head: `20260823_0035`, stacked after the current course-copy safety migration.
- Focused backend admission/auth/CLI/migration/quiz/course-copy/dashboard suite passes 95/95.
- Full backend run collected 424 tests: 409 passed and 4 skipped. The remaining 11 failures are confined to Windows sandbox denial for the configured AppData upload directory; the host-access rerun was not permitted, so this environment caveat is reported rather than hidden.
- Frontend TypeScript check passes; full Vitest suite passes 26 files / 51 tests.
- Production frontend build passes with the existing source-map and large-chunk warnings.
- Generated OpenAPI JSON parses successfully with 138 paths, including the admin policy, self-entitlement, quiz, course-copy, and student-dashboard routes.
- `git diff --check` passes.

## Suggested review order

1. Migration and access-control models.
2. Registration authorization and normalized email handling.
3. Central execution reservation and Flow failure behavior.
4. Admin/self APIs and Settings UI.
5. Operator documentation and rollout guidance.

## Out of scope for v1

- Provider token or price reconciliation, refunds, pooled organization quotas, and dollar guarantees.
- Account suspension, SSO policy, invite email delivery, and application-level IP allowlisting.
- Nightingale-specific policy or hosted-instance assumptions.
- Deployment, merge, or enabling the controls on an existing installation.
