### PR TITLE
perf: compress bundled server responses

### DIFF
--- a/src/fair_platform/backend/main.py
+++ b/src/fair_platform/backend/main.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.gzip import GZipMiddleware
 
 from fair_platform.backend.data.database import init_db
 from fair_platform.backend.core.config import validate_security_configuration
@@ -118,6 +119,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(GZipMiddleware, minimum_size=500, compresslevel=6)
 
 app.include_router(users_router, prefix="/api/users", tags=["users"])
 app.include_router(courses_router, prefix="/api/courses", tags=["courses"])

--- a/tests/test_response_compression.py
+++ b/tests/test_response_compression.py
@@ -1,0 +1,11 @@
+from starlette.middleware.gzip import GZipMiddleware
+
+from fair_platform.backend.main import app
+
+
+def test_application_compresses_large_responses() -> None:
+    middleware = next(
+        item for item in app.user_middleware if item.cls is GZipMiddleware
+    )
+
+    assert middleware.kwargs == {"minimum_size": 500, "compresslevel": 6}


### PR DESCRIPTION
## Summary

- enable Starlette gzip compression for responses over 500 bytes
- reduce the bundled frontend bootstrap transfer substantially on constrained remote connections
- add a regression check for the application middleware configuration

## Validation

- `pytest -q tests/test_response_compression.py tests/test_thin_core_contract.py` (5 passed)
- Ruff check passed
- runtime probe returned `Content-Encoding: gzip` and compressed 10 KB to 45 bytes
- `git diff --check` passed