### PR TITLE
feat(ui): add mobile swipe gestures for sidebars

### DIFF
--- a/frontend-dev/src/components/ui/sidebar.tsx
+++ b/frontend-dev/src/components/ui/sidebar.tsx
@@ -4,6 +4,7 @@ import { cva, VariantProps } from "class-variance-authority";
 import { PanelLeftIcon, PanelRightIcon } from "lucide-react";
 
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useSidebarSwipe } from "@/hooks/use-sidebar-swipe";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -204,6 +205,13 @@ function SidebarProvider({
     storageKey: `${cookieName}_width`,
   });
 
+  useSidebarSwipe({
+    side: "left",
+    open: openMobile,
+    onOpenChange: setOpenMobile,
+    enabled: isMobile,
+  });
+
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
   const [_open, _setOpen] = React.useState(defaultOpen);
@@ -353,6 +361,13 @@ function FlowSidebarProvider({
     maxWidth,
     resizable,
     storageKey: `${cookieName}_width`,
+  });
+
+  useSidebarSwipe({
+    side: "right",
+    open: openMobile,
+    onOpenChange: setOpenMobile,
+    enabled: isMobile,
   });
 
   // This is the internal state of the sidebar.

--- a/frontend-dev/src/hooks/use-sidebar-swipe.ts
+++ b/frontend-dev/src/hooks/use-sidebar-swipe.ts
@@ -1,0 +1,95 @@
+import * as React from "react";
+
+const EDGE_ZONE_PX = 32;
+const SWIPE_THRESHOLD_PX = 60;
+const DIRECTIONAL_RATIO = 1.2;
+const SCROLL_LOCK_PX = 10;
+
+export function useSidebarSwipe({
+  side,
+  open,
+  onOpenChange,
+  enabled,
+}: {
+  side: "left" | "right";
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  enabled: boolean;
+}) {
+  const startRef = React.useRef<{ x: number; y: number } | null>(null);
+  const lockedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!enabled) return;
+
+    const isHorizontalSwipe = (dx: number, dy: number) =>
+      Math.abs(dx) >= SWIPE_THRESHOLD_PX &&
+      Math.abs(dx) > Math.abs(dy) * DIRECTIONAL_RATIO;
+
+    const opensFromEdge = (dx: number) => {
+      if (open || dx === 0) return false;
+      return side === "left"
+        ? dx > 0 && startRef.current!.x <= EDGE_ZONE_PX
+        : dx < 0 && window.innerWidth - startRef.current!.x <= EDGE_ZONE_PX;
+    };
+
+    const closesWithSwipe = (dx: number) => {
+      if (!open) return false;
+      return side === "left" ? dx < 0 : dx > 0;
+    };
+
+    const handleTouchStart = (event: TouchEvent) => {
+      if (event.touches.length !== 1) return;
+      const touch = event.touches[0];
+      startRef.current = { x: touch.clientX, y: touch.clientY };
+      lockedRef.current = false;
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      const start = startRef.current;
+      if (!start) return;
+      const touch = event.touches[0];
+      if (!touch) return;
+
+      const dx = touch.clientX - start.x;
+      const dy = touch.clientY - start.y;
+
+      if (
+        !lockedRef.current &&
+        Math.abs(dx) > SCROLL_LOCK_PX &&
+        Math.abs(dx) > Math.abs(dy)
+      ) {
+        lockedRef.current = true;
+      }
+
+      if (lockedRef.current && event.cancelable) {
+        event.preventDefault();
+      }
+
+      if (isHorizontalSwipe(dx, dy)) {
+        if (opensFromEdge(dx) || closesWithSwipe(dx)) {
+          onOpenChange(!open);
+          startRef.current = null;
+          lockedRef.current = false;
+        }
+      }
+    };
+
+    const handleTouchEnd = () => {
+      startRef.current = null;
+      lockedRef.current = false;
+    };
+
+    window.addEventListener("touchstart", handleTouchStart, { passive: true });
+    window.addEventListener("touchmove", handleTouchMove, { passive: false });
+    window.addEventListener("touchend", handleTouchEnd);
+    window.addEventListener("touchcancel", handleTouchEnd);
+
+    return () => {
+      window.removeEventListener("touchstart", handleTouchStart);
+      window.removeEventListener("touchmove", handleTouchMove);
+      window.removeEventListener("touchend", handleTouchEnd);
+      window.removeEventListener("touchcancel", handleTouchEnd);
+    };
+  }, [side, open, onOpenChange, enabled]);
+}


### PR DESCRIPTION
## Summary
- Adds touch swipe gestures for the mobile sidebars via a new `useSidebarSwipe` hook, wired into both `SidebarProvider` (left) and `FlowSidebarProvider` (right)
- Main sidebar: swipe right from the left screen edge to open, swipe left to close
- Assignments/workflows sidebar: mirrored — swipe left from the right edge to open, swipe right to close

## Details
- Open gestures only trigger from a 32px edge zone so vertical scrolling and in-page horizontal interactions aren't hijacked
- Close gestures require a dominant horizontal swipe (60px threshold) and lock scrolling only once horizontal intent is detected
- Gestures are active only on mobile (<768px), matching when the Sheet-based sidebar is used