### PR TITLE
feat(ui): larger desktop default scale with compact interface size preference

### DIFF
--- a/frontend-dev/src/components/settings/sections/preferences-section.tsx
+++ b/frontend-dev/src/components/settings/sections/preferences-section.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 
 import { usePreferenceSettings } from "@/hooks/use-preference-settings";
+import type { UiScale } from "@/hooks/use-preference-settings";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -19,10 +20,12 @@ export function PreferencesSection() {
     effectiveLanguage,
     effectiveSimpleView,
     effectiveDevMode,
+    effectiveUiScale,
     setThemePreference,
     setLanguagePreference,
     setSimpleViewPreference,
     setDevModePreference,
+    setUiScalePreference,
     isSaving,
   } = usePreferenceSettings();
 
@@ -60,6 +63,22 @@ export function PreferencesSection() {
           <SelectContent>
             <SelectItem value="en">{t("settings.languages.en")}</SelectItem>
             <SelectItem value="es">{t("settings.languages.es")}</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="settings-ui-scale">{t("settings.fields.uiScale")}</Label>
+        <Select
+          value={effectiveUiScale}
+          onValueChange={(value) => setUiScalePreference(value as UiScale)}
+        >
+          <SelectTrigger id="settings-ui-scale" className="w-full">
+            <SelectValue placeholder={t("settings.fields.uiScale")} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="default">{t("settings.interfaceSizes.default")}</SelectItem>
+            <SelectItem value="compact">{t("settings.interfaceSizes.compact")}</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/frontend-dev/src/globals.css
+++ b/frontend-dev/src/globals.css
@@ -163,9 +163,24 @@
 
 @layer base {
     html {
-        /* Set root font size to scale up all text, spacing, and icons (relative to rem) */
-        /* Browser default is 16px (100%). 106.25% makes 1rem = 17px. */
-        font-size: 106.25%;
+        /*
+         * Root font size scales all text, spacing, and icons (Tailwind utilities are rem-based).
+         * Browser default is 16px (100%). Mobile keeps 106.25% (1rem = 17px);
+         * desktop defaults to 125% to match Chrome's 125% zoom.
+         * The "ui-scale-compact" class (set via Preferences) opts down to 100%.
+         */
+        --ui-scale: 106.25%;
+        font-size: var(--ui-scale);
+    }
+
+    @media (min-width: 768px) {
+        html {
+            --ui-scale: 125%;
+        }
+    }
+
+    html.ui-scale-compact {
+        --ui-scale: 100%;
     }
 
     * {

--- a/frontend-dev/src/hooks/use-preference-settings.ts
+++ b/frontend-dev/src/hooks/use-preference-settings.ts
@@ -7,6 +7,7 @@ import { useAuth } from "@/contexts/auth-context";
 
 export type ThemeMode = "system" | "light" | "dark";
 export type LanguageCode = "en" | "es";
+export type UiScale = "default" | "compact";
 
 const normalizeLanguage = (lang: string | undefined): LanguageCode =>
   lang?.toLowerCase().startsWith("es") ? "es" : "en";
@@ -21,21 +22,25 @@ export function usePreferenceSettings() {
   const localLanguage = useLocalPreference<LanguageCode | undefined>("ui.language").value;
   const localSimpleView = useLocalPreference<boolean | undefined>("ui.simpleView").value;
   const localDevMode = useLocalPreference<boolean | undefined>("ui.devMode").value;
+  const localUiScale = useLocalPreference<UiScale | undefined>("ui.uiScale").value;
 
   const setLocalTheme = useLocalPreference<ThemeMode>("ui.theme").setValue;
   const setLocalLanguage = useLocalPreference<LanguageCode>("ui.language").setValue;
   const setLocalSimpleView = useLocalPreference<boolean>("ui.simpleView").setValue;
   const setLocalDevMode = useLocalPreference<boolean>("ui.devMode").setValue;
+  const setLocalUiScale = useLocalPreference<UiScale>("ui.uiScale").setValue;
 
   const serverTheme = useUserSetting<ThemeMode>("preferences.theme", "system").value;
   const serverLanguage = useUserSetting<LanguageCode>("preferences.language", "en").value;
   const serverSimpleView = useUserSetting<boolean>("preferences.simpleView", false).value;
   const serverDevMode = useUserSetting<boolean>("preferences.devMode", false).value;
+  const serverUiScale = useUserSetting<UiScale>("preferences.uiScale", "default").value;
 
   const effectiveTheme = localTheme ?? serverTheme ?? (theme as ThemeMode);
   const effectiveLanguage = localLanguage ?? serverLanguage ?? normalizeLanguage(i18n.language);
   const effectiveSimpleView = localSimpleView ?? serverSimpleView ?? false;
   const effectiveDevMode = localDevMode ?? serverDevMode ?? false;
+  const effectiveUiScale = localUiScale ?? serverUiScale ?? "default";
 
   const setThemePreference = (nextTheme: ThemeMode) => {
     setTheme(nextTheme);
@@ -67,15 +72,24 @@ export function usePreferenceSettings() {
     }
   };
 
+  const setUiScalePreference = (nextUiScale: UiScale) => {
+    setLocalUiScale(nextUiScale);
+    if (isAuthenticated) {
+      updateSetting.mutate({ path: "preferences.uiScale", value: nextUiScale });
+    }
+  };
+
   return {
     effectiveTheme,
     effectiveLanguage,
     effectiveSimpleView,
     effectiveDevMode,
+    effectiveUiScale,
     setThemePreference,
     setLanguagePreference,
     setSimpleViewPreference,
     setDevModePreference,
+    setUiScalePreference,
     isSaving: updateSetting.isPending,
   };
 }

--- a/frontend-dev/src/hooks/use-user-settings.ts
+++ b/frontend-dev/src/hooks/use-user-settings.ts
@@ -156,6 +156,7 @@ const normalizeFallbackSettings = (
         devMode: false,
         theme: "system",
         language: "en",
+        uiScale: "default",
       },
     },
     baseSettings,

--- a/frontend-dev/src/i18n/locales/en.json
+++ b/frontend-dev/src/i18n/locales/en.json
@@ -89,6 +89,7 @@
       "password": "Password",
       "theme": "Theme",
       "language": "Language",
+      "uiScale": "Interface Size",
       "simpleView": "Simple View",
       "simpleViewDescription": "Condense dense screens for power users and instructors.",
       "devMode": "Developer Mode",
@@ -134,6 +135,10 @@
     "languages": {
       "en": "English",
       "es": "Spanish"
+    },
+    "interfaceSizes": {
+      "default": "Default",
+      "compact": "Compact"
     },
     "empty": {
       "title": "Section in development",

--- a/frontend-dev/src/i18n/locales/es.json
+++ b/frontend-dev/src/i18n/locales/es.json
@@ -89,6 +89,7 @@
       "password": "Contraseña",
       "theme": "Tema",
       "language": "Idioma",
+      "uiScale": "Tamaño de la interfaz",
       "simpleView": "Vista simple",
       "simpleViewDescription": "Condensa pantallas densas para usuarios avanzados e instructores.",
       "devMode": "Modo desarrollador",
@@ -134,6 +135,10 @@
     "languages": {
       "en": "Inglés",
       "es": "Español"
+    },
+    "interfaceSizes": {
+      "default": "Predeterminado",
+      "compact": "Compacto"
     },
     "empty": {
       "title": "Sección en desarrollo",

--- a/frontend-dev/src/providers.tsx
+++ b/frontend-dev/src/providers.tsx
@@ -8,7 +8,7 @@ import { useTheme } from "@/components/theme-provider";
 import { useTranslation } from "react-i18next";
 import { useLocalPreference } from "@/hooks/use-local-preference";
 import { useUserSetting } from "@/hooks/use-user-settings";
-import type { LanguageCode, ThemeMode } from "@/hooks/use-preference-settings";
+import type { LanguageCode, ThemeMode, UiScale } from "@/hooks/use-preference-settings";
 import api from "@/lib/api";
 
 
@@ -29,6 +29,8 @@ function SettingsRuntime() {
     useLocalPreference<boolean | undefined>("ui.simpleView");
   const { value: localDevMode, setValue: setLocalDevMode } =
     useLocalPreference<boolean | undefined>("ui.devMode");
+  const { value: localUiScale, setValue: setLocalUiScale } =
+    useLocalPreference<UiScale | undefined>("ui.uiScale");
   const { setValue: setLocalEmailEnabled } =
     useLocalPreference<boolean>("features.emailEnabled");
 
@@ -36,11 +38,13 @@ function SettingsRuntime() {
   const languageServer = useUserSetting<LanguageCode>("preferences.language", "en").value;
   const simpleViewServer = useUserSetting<boolean>("preferences.simpleView", false).value;
   const devModeServer = useUserSetting<boolean>("preferences.devMode", false).value;
+  const uiScaleServer = useUserSetting<UiScale>("preferences.uiScale", "default").value;
 
   const resolvedTheme = localTheme ?? themeServer;
   const resolvedLanguage = localLanguage ?? languageServer;
   const resolvedSimpleView = localSimpleView ?? simpleViewServer;
   const resolvedDevMode = localDevMode ?? devModeServer;
+  const resolvedUiScale = localUiScale ?? uiScaleServer;
 
   useEffect(() => {
     if (localTheme === undefined) {
@@ -85,6 +89,10 @@ function SettingsRuntime() {
   useEffect(() => {
     document.documentElement.classList.toggle("dev-mode", Boolean(resolvedDevMode));
   }, [resolvedDevMode]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("ui-scale-compact", resolvedUiScale === "compact");
+  }, [resolvedUiScale]);
 
   useEffect(() => {
     let active = true;


### PR DESCRIPTION
## Summary
- Desktop now defaults to a root font-size of 125% (`--ui-scale` variable), matching the look of Chrome at 125% zoom. Mobile keeps the previous 106.25% scale.
- New **Interface Size** preference in Settings → Preferences with `Default` (125%) and `Compact` (100%) options, for users who prefer everything smaller.
- Wired through the existing preference pattern: local preference `ui.uiScale`, server setting `preferences.uiScale` (default `"default"`), applied via a `ui-scale-compact` class on `<html>` in `SettingsRuntime`.
- i18n strings added for English and Spanish.

Since all Tailwind v4 spacing/text utilities are rem-based, the whole UI scales uniformly; the resizable sidebar already adapts via its rem→px helper.

## Testing
- `bun x tsc --noEmit` passes.
- `bun x vitest run` could not execute in this environment (Node 18 / ESM setup error, 0 tests ran) — pre-existing, unrelated to this change.