### PR TITLE
fix(ui): make sidebar swipe work from anywhere and prevent cross-open

### DIFF
--- a/frontend-dev/src/hooks/use-sidebar-swipe.test.tsx
+++ b/frontend-dev/src/hooks/use-sidebar-swipe.test.tsx
@@ -1,0 +1,96 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useSidebarSwipe } from "./use-sidebar-swipe";
+
+function touch(type: string, x: number, y: number, cancelable = true) {
+  const event = new Event(type, { bubbles: true, cancelable }) as Event & {
+    touches: Array<{ clientX: number; clientY: number }>;
+  };
+  Object.defineProperty(event, "touches", {
+    value: [{ clientX: x, clientY: y }],
+  });
+  return event;
+}
+
+function swipe(points: Array<[number, number]>, cancelable = true) {
+  const [startX, startY] = points[0];
+  window.dispatchEvent(touch("touchstart", startX, startY));
+  for (const [x, y] of points.slice(1)) {
+    window.dispatchEvent(touch("touchmove", x, y, cancelable));
+  }
+  window.dispatchEvent(touch("touchend", startX, startY));
+}
+
+describe("useSidebarSwipe", () => {
+  it("opens the left sidebar on rightward edge swipe", () => {
+    const onOpenChange = vi.fn();
+    renderHook(() =>
+      useSidebarSwipe({
+        side: "left",
+        open: false,
+        onOpenChange,
+        enabled: true,
+      }),
+    );
+
+    swipe([
+      [10, 300],
+      [100, 305],
+    ]);
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it("closes the left sidebar on leftward swipe", () => {
+    const onOpenChange = vi.fn();
+    renderHook(() =>
+      useSidebarSwipe({ side: "left", open: true, onOpenChange, enabled: true }),
+    );
+
+    swipe([
+      [200, 300],
+      [100, 305],
+    ]);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("ignores vertical scrolls", () => {
+    const onOpenChange = vi.fn();
+    renderHook(() =>
+      useSidebarSwipe({
+        side: "left",
+        open: false,
+        onOpenChange,
+        enabled: true,
+      }),
+    );
+
+    swipe([
+      [10, 100],
+      [20, 400],
+    ]);
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("opens the left sidebar on rightward swipe from anywhere when closed", () => {
+    const onOpenChange = vi.fn();
+    renderHook(() =>
+      useSidebarSwipe({
+        side: "left",
+        open: false,
+        onOpenChange,
+        enabled: true,
+      }),
+    );
+
+    swipe([
+      [200, 300],
+      [320, 305],
+    ]);
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/frontend-dev/src/hooks/use-sidebar-swipe.ts
+++ b/frontend-dev/src/hooks/use-sidebar-swipe.ts
@@ -1,7 +1,6 @@
 import * as React from "react";
 
-const EDGE_ZONE_PX = 32;
-const SWIPE_THRESHOLD_PX = 60;
+const SWIPE_THRESHOLD_PX = 50;
 const DIRECTIONAL_RATIO = 1.2;
 const SCROLL_LOCK_PX = 10;
 
@@ -28,9 +27,9 @@ export function useSidebarSwipe({
 
     const opensFromEdge = (dx: number) => {
       if (open || dx === 0) return false;
-      return side === "left"
-        ? dx > 0 && startRef.current!.x <= EDGE_ZONE_PX
-        : dx < 0 && window.innerWidth - startRef.current!.x <= EDGE_ZONE_PX;
+      // If any sidebar is currently open, don't open another - close has priority
+      if (document.querySelector('[data-slot="sheet-overlay"]')) return false;
+      return side === "left" ? dx > 0 : dx < 0;
     };
 
     const closesWithSwipe = (dx: number) => {


### PR DESCRIPTION
Makes the mobile swipe gesture reliable:

- Open now works from any horizontal swipe position (not just the 32px edge zone) with a slightly lower 50px threshold, so sliding right anywhere opens the main (left) sidebar.
- When a sidebar is open, the opposite sidebar's open gesture is blocked (overlay check) so a close swipe doesn't simultaneously open the other sidebar.

Verified with unit tests (useSidebarSwipe) and live on https://alam.tailf325ec.ts.net:8443 (hard refresh).